### PR TITLE
Link filters/search

### DIFF
--- a/components/juridische-houdbaarheid-tooltip.js
+++ b/components/juridische-houdbaarheid-tooltip.js
@@ -81,7 +81,7 @@ export default function ToolTips({ children, icon, data }) {
                       <div className='px-4 sm:px-6'>
                         <Dialog.Title className='text-lg font-medium text-gray-900'>
                           {' '}
-                          Juridische houdbaarheid
+                          Juridisch haalbaarheid
                         </Dialog.Title>
                       </div>
                       <div className='relative mt-6 flex-1 px-4 sm:px-6'>

--- a/components/layouts/measures-layout.js
+++ b/components/layouts/measures-layout.js
@@ -146,7 +146,6 @@ export default function MeasuresLayout(props) {
     // added check for data to have been retrieved here
     if (data) {
       let filteredLaws = data;
-      
       // filter for thema
       filteredLaws = filteredLaws?.filter((element) => {
         return element.thema === props.thema;
@@ -157,21 +156,6 @@ export default function MeasuresLayout(props) {
       let numProvinciaal = 0;
       let numGemeentelijk = 0;
 
-      filteredLaws.map((measure) => {
-        if (measure.wettelijkBevoegdheidsniveau.includes('Europees')) {
-          numEuropee += 1;
-        }
-        if (measure.wettelijkBevoegdheidsniveau.includes('Nationaal')) {
-          numNationaal += 1;
-        }
-        if (measure.wettelijkBevoegdheidsniveau.includes('Provinciaal')) {
-          numProvinciaal += 1;
-        }
-        if (measure.wettelijkBevoegdheidsniveau.includes('Gemeentelijk')) {
-          numGemeentelijk += 1;
-        }
-      })
-
       let numR1 = 0;
       let numR2 = 0;
       let numR3 = 0;
@@ -179,39 +163,8 @@ export default function MeasuresLayout(props) {
       let numR5 = 0;
       let numR6 = 0;
 
-      filteredLaws.map((measure) => {
-        if (measure.rLadder.includes('R1')) {
-          numR1 += 1;
-        }
-        if (measure.rLadder.includes('R2')) {
-          numR2 += 1;
-        }
-        if (measure.rLadder.includes('R3')) {
-          numR3 += 1;
-        }
-        if (measure.rLadder.includes('R4')) {
-          numR4 += 1;
-        }
-        if (measure.rLadder.includes('R5')) {
-          numR5 += 1;
-        }
-        if (measure.rLadder.includes('R6')) {
-          numR6 += 1;
-        }
-    })
-
     let numExample = 0;
     let numGuidline = 0;
-
-    // the numbers are set at the beginning ... reset also at the end?
-  filteredLaws.map((measure) => {
-      if (measure.extraContent.includes('Example')) {
-        numExample += 1;
-      }
-      if (measure.extraContent.includes('Guideline')) {
-        numGuidline += 1;
-      }
-  })
    
       let numJHLow = 0;
       let numJHMedium = 0;
@@ -269,9 +222,8 @@ export default function MeasuresLayout(props) {
           });
         }
       }
+    
       // old filter logic
-      {
-        /* 
       if (selected.rLadder.length > 0) {
         if (selected.rLadder.includes('R1')) {
           filteredLaws = filteredLaws.filter((element) => { 
@@ -304,18 +256,22 @@ export default function MeasuresLayout(props) {
           })
         }
       }
-      */
-      }
+
+     
+          
 
       // potential new filter logic but need to make dynamic counting work
+      {/*
       if (selected.rLadder.length > 0) {
-        let temparr = [];
-        for (let i = 0; i < filteredLaws.length; i++) {
-          if (filteredLaws[i].rLadder.some((rValue) => selected.rLadder.includes(rValue)) === true)
-            temparr.push(filteredLaws[i]);
-        }
-        filteredLaws = temparr;
-      }
+            let temparr = [];
+            for (let i = 0; i < filteredLaws.length; i++) {
+              if (filteredLaws[i].rLadder.some((rValue) => selected.rLadder.includes(rValue)) === true)
+                temparr.push(filteredLaws[i]);
+            }
+            filteredLaws = temparr;
+          }
+        
+    */}
 
       // FILTER LOGIC FOR SINGLE CHOICE ATTRIBUTES
       if (selected.rechtsgebied.length > 0) {
@@ -380,8 +336,6 @@ export default function MeasuresLayout(props) {
           numGuidline += 1;
         }
         
-
-        
         if (measure.wettelijkBevoegdheidsniveau.includes('Europees')) {
           numEuropee += 1;
         }
@@ -416,7 +370,6 @@ export default function MeasuresLayout(props) {
           numGron += 1;
         }
         
-        {/* 
         if (measure.rLadder.includes('R1')) {
           numR1 += 1;
         }
@@ -435,7 +388,6 @@ export default function MeasuresLayout(props) {
         if (measure.rLadder.includes('R6')) {
           numR6 += 1;
         }
-        */}
 
         if (measure.juridischHaalbaarheid === 'Low') {
           numJHLow += 1;

--- a/components/layouts/measures-layout.js
+++ b/components/layouts/measures-layout.js
@@ -10,7 +10,7 @@ import {
   subrechtsgebied,
   juridischHaalbaarheid,
   juridischInvloed,
-  // extraContent,
+  extraContent,
   rLadder,
 } from '../../dataFilter';
 
@@ -23,21 +23,6 @@ import { groq } from 'next-sanity';
 
 // creating objects for persisting values
 const useSelectedState = createPersistedState('selected');
-
-{/* NEW DATA STRUCTURE FOR FILTERS
-2 different types 
-[] with single string value
-[] array with multiple values
-
-wettelijkBevoegdheidsniveau - was true/false now array of strings ['1','2']
-rLadder - was true/falie now array of strings ['1', '2']
-extraContent - new array of strings ['1', '2']
-
-rechtsgebied - [string] - one value DONE
-subrechtsgebied - [string] - one value DONE
-juridischHaalbaarheid - was number now [string] - one value
-juridischInvloed - new [string] - one value
-*/}
 
 export default function MeasuresLayout(props) {
   // need to add error check ? or replace the fetcher function in utils/filter funcition
@@ -117,13 +102,17 @@ export default function MeasuresLayout(props) {
   const [numberOfCont, setNumberOfCont] = useState(0);
   const [numberOfGron, setNumberOfGron] = useState(0);
 
-  // const [numberOfExample, setNumberOfExample] = useState(0);
-  // const [numberOfGuideline, setNumberOfGuideline] = useState(0);
+  const [numberOfExample, setNumberOfExample] = useState(0);
+  const [numberOfGuideline, setNumberOfGuideline] = useState(0);
 
   const [searchValue, setSearchValue] = useState('');
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
+
+  // taking the value of the check box and creating
+  // creates array for each attribute. [r1, r2 , Rn]
   const handleFilters = (checkboxState, key) => {
+    // key is name oc filter -checkbox state is the value 
     const newFilters = { ...selected };
     newFilters[key] = checkboxState;
     setSelected(newFilters);
@@ -138,7 +127,6 @@ export default function MeasuresLayout(props) {
       juridischHaalbaarheid: [],
       juridischInvloed: [],
       extraContent: [],
-
     });
 
     wettelijkFilterRef.current.reset();
@@ -168,12 +156,12 @@ export default function MeasuresLayout(props) {
       let numPrivaat = 0;
       let numFiscaal = 0;
       // this will no longer work
-      let numR1 = 0;
-      let numR2 = 0;
-      let numR3 = 0;
-      let numR4 = 0;
-      let numR5 = 0;
-      let numR6 = 0;
+      let numR1 = 4;
+      let numR2 = 4;
+      let numR3 = 4;
+      let numR4 = 4;
+      let numR5 = 4;
+      let numR6 = 4;
 
       let numJHLow = 0;
       let numJHMedium = 0;
@@ -183,8 +171,8 @@ export default function MeasuresLayout(props) {
       let numJIMedium = 0;
       let numJIHigh = 0;
 
-      // let numExample = 0;
-      // let numGuidline = 0;
+      let numExample = 0;
+      let numGuidline = 0;
 
       let numErp = 0;
       let numOmg = 0;
@@ -195,66 +183,83 @@ export default function MeasuresLayout(props) {
       filteredLaws = filteredLaws?.filter((element) => {
         return element.thema === props.thema;
       });
-      
+
+      // FILTER LOGIC FOR MULTICHOICE ATTRIBUTES
+      if (selected.extraContent.length > 0) {
+        if (selected.extraContent.includes('Example')) {
+          filteredLaws = filteredLaws.filter((element) => {
+            return element.extraContent.includes('Example');
+          });
+          console.log(filteredLaws, '?')
+        }
+        if (selected.extraContent.includes('Guideline')) {
+          filteredLaws = filteredLaws.filter((element) => {
+            return element.extraContent.includes('Guideline');
+          });
+        }
+      }
 
       if (selected.wettelijkBevoegdheidsniveau.length > 0) {
         if (selected.wettelijkBevoegdheidsniveau.includes('Europees')) {
           filteredLaws = filteredLaws.filter((element) => {
-            return element.europees;
+            return element.wettelijkBevoegdheidsniveau.includes('Europees');
           });
         }
         if (selected.wettelijkBevoegdheidsniveau.includes('Nationaal')) {
           filteredLaws = filteredLaws.filter((element) => {
-            return element.nationaal;
+            return element.wettelijkBevoegdheidsniveau.includes('Nationaal');
           });
         }
         if (selected.wettelijkBevoegdheidsniveau.includes('Provinciaal')) {
           filteredLaws = filteredLaws.filter((element) => {
-            return element.provinciaal;
+            return element.wettelijkBevoegdheidsniveau.includes('Provinciaal');
           });
         }
         if (selected.wettelijkBevoegdheidsniveau.includes('Gemeentelijk')) {
           filteredLaws = filteredLaws.filter((element) => {
-            return element.gemeentelijk;
+            return element.wettelijkBevoegdheidsniveau.includes('Gemeentelijk');
           });
         }
       }
+      console.log(filteredLaws, 'test')
+      
 
       if (selected.rLadder.length > 0) {
         if (selected.rLadder.includes('R1')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R1;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R1')
+          })
         }
         if (selected.rLadder.includes('R2')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R2;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R2')
+          })
         }
         if (selected.rLadder.includes('R3')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R3;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R3')
+          })
         }
         if (selected.rLadder.includes('R4')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R4;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R4')
+          })
         }
         if (selected.rLadder.includes('R5')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R5;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R5')
+          })
         }
         if (selected.rLadder.includes('R6')) {
-          filteredLaws = filteredLaws.filter((element) => {
-            return element.R6;
-          });
+          filteredLaws = filteredLaws.filter((element) => { 
+            return element.rLadder.includes('R6')
+          })
         }
       }
-
+      
+      // FILTER LOGIC FOR SINGLE CHOICE ATTRIBUTES
       if (selected.rechtsgebied.length > 0) {
-        filteredLaws = filteredLaws?.filter((element) => {
+        filteredLaws = filteredLaws.filter((element) => {
           return selected.rechtsgebied.includes(element.rechtsgebied);
         });
       }
@@ -275,13 +280,6 @@ export default function MeasuresLayout(props) {
       if (selected.juridischInvloed.length > 0) {
         filteredLaws = filteredLaws.filter((element) => {
           return selected.juridischInvloed.includes(element.juridischInvloed);
-        });
-      }
-
-      // new for extra contnet
-      if (selected.extraContent.length > 0) {
-        filteredLaws = filteredLaws.filter((element) => {
-          return selected.extraContent.includes(element.extraContent);
         });
       }
 
@@ -308,12 +306,7 @@ export default function MeasuresLayout(props) {
       const lawResults = searchValue ? results.map((result) => result.item) : filteredLaws;
       filteredLaws = lawResults;
 
-      console.log(filteredLaws)
-      {/*
-      // display scores in consol for testing
-      const scores = results.map((result) => result.score)
-      console.log(scores)
-       */}
+    
 
       // setting values for autocomplete
       setSelectedResults(filteredLaws);
@@ -321,19 +314,24 @@ export default function MeasuresLayout(props) {
 
       // dynamically calculate filter numbers
       filteredLaws?.map((measure) => {
-
         // add extra content
+        if (measure.extraContent.includes('Example')) {
+          numExample += 1;
+        }
+        if (measure.extraContent.includes('Guideline')) {
+          numGuidline += 1;
+        }
 
-        if (measure.europees) {
+        if (measure.wettelijkBevoegdheidsniveau.includes('Europees')) {
           numEuropee += 1;
         }
-        if (measure.nationaal) {
+        if (measure.wettelijkBevoegdheidsniveau.includes('Nationaal')) {
           numNationaal += 1;
         }
-        if (measure.provinciaal) {
+        if (measure.wettelijkBevoegdheidsniveau.includes('Provinciaal')) {
           numProvinciaal += 1;
         }
-        if (measure.gemeentelijk) {
+        if (measure.wettelijkBevoegdheidsniveau.includes('Gemeentelijk')) {
           numGemeentelijk += 1;
         }
 
@@ -356,23 +354,24 @@ export default function MeasuresLayout(props) {
         } else if (measure.subrechtsgebied === 'Gronduitgifte') {
           numGron += 1;
         }
+        
 
-        if (measure.R1) {
-          numR1 += 1;
+        if (measure.rLadder.includes('R1')) {
+          numR1 += 1
         }
-        if (measure.R2) {
+        if (measure.rLadder.includes('R2')) {
           numR2 += 1;
         }
-        if (measure.R3) {
+        if (measure.rLadder.includes('R3')) {
           numR3 += 1;
         }
-        if (measure.R4) {
+        if (measure.rLadder.includes('R4')) {
           numR4 += 1;
         }
-        if (measure.R5) {
+        if (measure.rLadder.includes('R5')) {
           numR5 += 1;
         }
-        if (measure.R6) {
+        if (measure.rLadder.includes('R6')) {
           numR6 += 1;
         }
 
@@ -397,6 +396,9 @@ export default function MeasuresLayout(props) {
 
       setLaws(filteredLaws);
       setNumberOfLaws(filteredLaws?.length);
+
+      setNumberOfExample(numExample);
+      setNumberOfGuideline(numGuidline)
 
       setNumberOfEuropee(numEuropee);
       setNumberOfNationaal(numNationaal);
@@ -433,6 +435,13 @@ export default function MeasuresLayout(props) {
 
   // effect to check for data from persisted state from localStorage and update values when needed
   useEffect(() => {
+    if (
+      selected.extraContent.length !== 0 &&
+      typeof extraContentFilterRef.current !== 'undefined'
+    ) {
+      extraContentFilterRef.current.set(selected.extraContent);
+    }
+
     if (
       selected.wettelijkBevoegdheidsniveau.length !== 0 &&
       typeof wettelijkFilterRef.current !== 'undefined'
@@ -525,6 +534,18 @@ export default function MeasuresLayout(props) {
                   </div>
                   <div className='flex-1 h-0 overflow-y-auto'>
                     <div className='p-8 '>
+                    <SearchFilter
+                        ref={extraContentFilterRef}
+                        title='Extra Content'
+                        list={extraContent}
+                        filterNumbers={[
+                          numberOfExample,
+                          numberOfGuideline,
+                        ]}
+                        handleFilters={(checkboxState) =>
+                          handleFilters(checkboxState, 'extraContent')
+                        }
+                      />
                       <SearchFilter
                         ref={wettelijkFilterRef}
                         title='Bevoegdheidsniveau'
@@ -784,6 +805,18 @@ export default function MeasuresLayout(props) {
       </div>
       <div className='grid grid-cols-1 sm:grid-cols-4'>
         <div className='hidden lg:block p-3 my-4'>
+          <SearchFilter
+              ref={extraContentFilterRef}
+              title='Extra Content'
+              list={extraContent}
+              filterNumbers={[
+                numberOfExample,
+                numberOfGuideline,
+              ]}
+              handleFilters={(checkboxState) =>
+                handleFilters(checkboxState, 'extraContent')
+              }
+           />
           <SearchFilter
             ref={wettelijkFilterRef}
             title='Bevoegdheidsniveau'

--- a/components/layouts/measures-layout.js
+++ b/components/layouts/measures-layout.js
@@ -8,7 +8,9 @@ import {
   wettelijkBevoegdheidsniveau,
   rechtsgebied,
   subrechtsgebied,
-  juridischeHoudbaarheid,
+  juridischHaalbaarheid,
+  juridischInvloed,
+  // extraContent,
   rLadder,
 } from '../../dataFilter';
 
@@ -22,15 +24,32 @@ import { groq } from 'next-sanity';
 // creating objects for persisting values
 const useSelectedState = createPersistedState('selected');
 
+{/* NEW DATA STRUCTURE FOR FILTERS
+2 different types 
+[] with single string value
+[] array with multiple values
+
+wettelijkBevoegdheidsniveau - was true/false now array of strings ['1','2']
+rLadder - was true/falie now array of strings ['1', '2']
+extraContent - new array of strings ['1', '2']
+
+rechtsgebied - [string] - one value DONE
+subrechtsgebied - [string] - one value DONE
+juridischHaalbaarheid - was number now [string] - one value
+juridischInvloed - new [string] - one value
+*/}
+
 export default function MeasuresLayout(props) {
-  // need to add error ?
+  // need to add error check ? or replace the fetcher function in utils/filter funcition
   const { data } = useSWR(groq`*[_type == "measure"]`, (query) => client.fetch(query));
   // creating references to access child component functions
   const wettelijkFilterRef = useRef();
   const rechtsgebiedFilterRef = useRef();
   const subrechtsgebiedFilterRef = useRef();
   const rLadderFilterRef = useRef();
-  const juridischeFilterRef = useRef();
+  const juridischHaalbaarheidFilterRef = useRef();
+  const juridischInvloedFilterRef = useRef();
+  const extraContentFilterRef = useRef();
 
   const [laws, setLaws] = useState(data);
 
@@ -39,7 +58,9 @@ export default function MeasuresLayout(props) {
     rechtsgebied: [],
     subrechtsgebied: [],
     rLadder: [],
-    juridischeHoudbaarheid: [],
+    juridischHaalbaarheid: [],
+    juridischInvloed: [],
+    extraContent: [],
   });
 
   const dummyArray = [];
@@ -48,13 +69,16 @@ export default function MeasuresLayout(props) {
     selected.rechtsgebied,
     selected.subrechtsgebied,
     selected.rLadder,
-    selected.juridischeHoudbaarheid,
+    selected.juridischHaalbaarheid,
+    selected.juridischInvloed,
+    selected.extraContent,
   );
 
   // autocomplete variables and funciton
   const [selectedResults, setSelectedResults] = useState(null);
   const [firstLaw, setFirstLaw] = useState(null);
 
+  {/* MAY NEED TO REDO SEARCH TO NOT HAVE setState inside useEffect */}
   const firstLawFunction = useCallback(() => {
     const firstLaw = selectedResults?.[0];
     return firstLaw;
@@ -79,17 +103,22 @@ export default function MeasuresLayout(props) {
   const [numberOfR5, setNumberOfR5] = useState(0);
   const [numberOfR6, setNumberOfR6] = useState(0);
 
-  const [numberOfJ1, setNumberOfJ1] = useState(0);
-  const [numberOfJ2, setNumberOfJ2] = useState(0);
-  const [numberOfJ3, setNumberOfJ3] = useState(0);
-  const [numberOfJ4, setNumberOfJ4] = useState(0);
-  const [numberOfJ5, setNumberOfJ5] = useState(0);
+  const [numberOfJHLow, setNumberOfJ1] = useState(0);
+  const [numberOfJHMedium, setNumberOfJ2] = useState(0);
+  const [numberOfJHHigh, setNumberOfJ3] = useState(0);
+
+  const [numberOfJILow, setNumberOfJILow] = useState(0);
+  const [numberOfJIMedium, setNumberOfJIMedium] = useState(0);
+  const [numberOfJIHigh, setNumberOfJIHigh] = useState(0);
 
   const [numberOfErp, setNumberOfErp] = useState(0);
   const [numberOfOmg, setNumberOfOmg] = useState(0);
   const [numberOfAan, setNumberOfAan] = useState(0);
   const [numberOfCont, setNumberOfCont] = useState(0);
   const [numberOfGron, setNumberOfGron] = useState(0);
+
+  // const [numberOfExample, setNumberOfExample] = useState(0);
+  // const [numberOfGuideline, setNumberOfGuideline] = useState(0);
 
   const [searchValue, setSearchValue] = useState('');
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -106,14 +135,19 @@ export default function MeasuresLayout(props) {
       rechtsgebied: [],
       subrechtsgebied: [],
       rLadder: [],
-      juridischeHoudbaarheid: [],
+      juridischHaalbaarheid: [],
+      juridischInvloed: [],
+      extraContent: [],
+
     });
 
     wettelijkFilterRef.current.reset();
     rechtsgebiedFilterRef.current.reset();
     subrechtsgebiedFilterRef.current.reset();
     rLadderFilterRef.current.reset();
-    juridischeFilterRef.current.reset();
+    juridischHaalbaarheidFilterRef.current.reset();
+    juridischInvloedFilterRef.current.reset();
+    extraContentFilterRef.current.reset();
 
     setFirstLaw(null);
     setSearchValue('');
@@ -133,7 +167,7 @@ export default function MeasuresLayout(props) {
       let numPubliek = 0;
       let numPrivaat = 0;
       let numFiscaal = 0;
-
+      // this will no longer work
       let numR1 = 0;
       let numR2 = 0;
       let numR3 = 0;
@@ -141,11 +175,16 @@ export default function MeasuresLayout(props) {
       let numR5 = 0;
       let numR6 = 0;
 
-      let numJ1 = 0;
-      let numJ2 = 0;
-      let numJ3 = 0;
-      let numJ4 = 0;
-      let numJ5 = 0;
+      let numJHLow = 0;
+      let numJHMedium = 0;
+      let numJHHigh = 0;
+
+      let numJILow = 0;
+      let numJIMedium = 0;
+      let numJIHigh = 0;
+
+      // let numExample = 0;
+      // let numGuidline = 0;
 
       let numErp = 0;
       let numOmg = 0;
@@ -156,6 +195,7 @@ export default function MeasuresLayout(props) {
       filteredLaws = filteredLaws?.filter((element) => {
         return element.thema === props.thema;
       });
+      
 
       if (selected.wettelijkBevoegdheidsniveau.length > 0) {
         if (selected.wettelijkBevoegdheidsniveau.includes('Europees')) {
@@ -219,19 +259,31 @@ export default function MeasuresLayout(props) {
         });
       }
 
-      if (selected.juridischeHoudbaarheid.length > 0) {
-        filteredLaws = filteredLaws.filter((element) => {
-          return selected.juridischeHoudbaarheid.includes(element.juridischeHoudbaarheid);
-        });
-      }
-
       if (selected.subrechtsgebied.length > 0) {
         filteredLaws = filteredLaws?.filter((element) => {
           return selected.subrechtsgebied.includes(element.subrechtsgebied);
         });
       }
 
+      if (selected.juridischHaalbaarheid?.length > 0) {
+        filteredLaws = filteredLaws.filter((element) => {
+          return selected.juridischHaalbaarheid.includes(element.juridischHaalbaarheid);
+        });
+      }
 
+      // new for JI
+      if (selected.juridischInvloed.length > 0) {
+        filteredLaws = filteredLaws.filter((element) => {
+          return selected.juridischInvloed.includes(element.juridischInvloed);
+        });
+      }
+
+      // new for extra contnet
+      if (selected.extraContent.length > 0) {
+        filteredLaws = filteredLaws.filter((element) => {
+          return selected.extraContent.includes(element.extraContent);
+        });
+      }
 
       const fuse = new Fuse(filteredLaws, {
         keys: [
@@ -255,11 +307,13 @@ export default function MeasuresLayout(props) {
       const results = fuse.search(searchValue);
       const lawResults = searchValue ? results.map((result) => result.item) : filteredLaws;
       filteredLaws = lawResults;
-      console.log(filteredLaws, 'Regels hergebruik producten')
 
+      console.log(filteredLaws)
+      {/*
       // display scores in consol for testing
       const scores = results.map((result) => result.score)
       console.log(scores)
+       */}
 
       // setting values for autocomplete
       setSelectedResults(filteredLaws);
@@ -267,6 +321,9 @@ export default function MeasuresLayout(props) {
 
       // dynamically calculate filter numbers
       filteredLaws?.map((measure) => {
+
+        // add extra content
+
         if (measure.europees) {
           numEuropee += 1;
         }
@@ -288,6 +345,18 @@ export default function MeasuresLayout(props) {
           numFiscaal += 1;
         }
 
+        if (measure.subrechtsgebied === 'Erfpacht') {
+          numErp += 1;
+        } else if (measure.subrechtsgebied === 'Omgevingsrecht') {
+          numOmg += 1;
+        } else if (measure.subrechtsgebied === 'Aanbesteding') {
+          numAan += 1;
+        } else if (measure.subrechtsgebied === 'Contracten') {
+          numCont += 1;
+        } else if (measure.subrechtsgebied === 'Gronduitgifte') {
+          numGron += 1;
+        }
+
         if (measure.R1) {
           numR1 += 1;
         }
@@ -307,29 +376,23 @@ export default function MeasuresLayout(props) {
           numR6 += 1;
         }
 
-        if (measure.juridischeHoudbaarheid === 1) {
-          numJ1 += 1;
-        } else if (measure.juridischeHoudbaarheid === 2) {
-          numJ2 += 1;
-        } else if (measure.juridischeHoudbaarheid === 3) {
-          numJ3 += 1;
-        } else if (measure.juridischeHoudbaarheid === 4) {
-          numJ4 += 1;
-        } else if (measure.juridischeHoudbaarheid === 5) {
-          numJ5 += 1;
+        
+        if (measure.juridischHaalbaarheid === 'Low') {
+          numJHLow += 1;
+        } else if (measure.juridischHaalbaarheid === 'Medium') {
+          numJHMedium += 1;
+        } else if (measure.juridischHaalbaarheid === 'High') {
+          numJHHigh += 1;
         }
 
-        if (measure.subrechtsgebied === 'Erfpacht') {
-          numErp += 1;
-        } else if (measure.subrechtsgebied === 'Omgevingsrecht') {
-          numOmg += 1;
-        } else if (measure.subrechtsgebied === 'Aanbesteding') {
-          numAan += 1;
-        } else if (measure.subrechtsgebied === 'Contracten') {
-          numCont += 1;
-        } else if (measure.subrechtsgebied === 'Gronduitgifte') {
-          numGron += 1;
+        if (measure.juridischInvloed === 'Low') {
+          numJILow += 1;
+        } else if (measure.juridischInvloed === 'Medium') {
+          numJIMedium += 1;
+        } else if (measure.juridischInvloed === 'High') {
+          numJIHigh += 1;
         }
+        
       });
 
       setLaws(filteredLaws);
@@ -351,11 +414,14 @@ export default function MeasuresLayout(props) {
       setNumberOfR5(numR5);
       setNumberOfR6(numR6);
 
-      setNumberOfJ1(numJ1);
-      setNumberOfJ2(numJ2);
-      setNumberOfJ3(numJ3);
-      setNumberOfJ4(numJ4);
-      setNumberOfJ5(numJ5);
+      
+      setNumberOfJ1(numJHLow);
+      setNumberOfJ2(numJHMedium);
+      setNumberOfJ3(numJHHigh);
+     
+      setNumberOfJILow(numJILow);
+      setNumberOfJIMedium(numJIMedium);
+      setNumberOfJIHigh(numJIHigh);
 
       setNumberOfErp(numErp);
       setNumberOfOmg(numOmg);
@@ -393,10 +459,17 @@ export default function MeasuresLayout(props) {
     }
 
     if (
-      selected.juridischeHoudbaarheid.length !== 0 &&
-      typeof juridischeFilterRef.current !== 'undefined'
+      selected.juridischHaalbaarheid?.length !== 0 &&
+      typeof juridischHaalbaarheidFilterRef.current !== 'undefined'
     ) {
-      juridischeFilterRef.current.set(selected.juridischeHoudbaarheid);
+      juridischHaalbaarheidFilterRef.current.set(selected.juridischHaalbaarheid);
+    }
+
+    if (
+      selected.juridischInvloed.length !== 0 && 
+      typeof juridischInvloedFilterRef.current !== 'undefined'
+    ) {
+      juridischInvloedFilterRef.current.set(selected.juridischInvloed)
     }
   });
   return (
@@ -470,11 +543,30 @@ export default function MeasuresLayout(props) {
                         ref={rechtsgebiedFilterRef}
                         title='Rechtsgebied'
                         list={rechtsgebied}
-                        filterNumbers={[numberOfPubliek, numberOfPrivaat, numberOfFiscaal]}
+                        filterNumbers={[
+                          numberOfPubliek, 
+                          numberOfPrivaat, 
+                          numberOfFiscaal]}
                         handleFilters={(checkboxState) =>
                           handleFilters(checkboxState, 'rechtsgebied')
                         }
                       />
+
+                      <SearchFilter
+                        ref={subrechtsgebiedFilterRef}
+                        title='Subrechtsgebied'
+                        list={subrechtsgebied}
+                        filterNumbers={[
+                          numberOfErp,
+                          numberOfOmg,
+                          numberOfAan,
+                          numberOfCont,
+                          numberOfGron,
+                        ]}
+                        handleFilters={(checkboxState) =>
+                          handleFilters(checkboxState, 'subrechtsgebied')
+                        }
+                      />  
                       <SearchFilter
                         ref={rLadderFilterRef}
                         title='R - ladder'
@@ -490,27 +582,27 @@ export default function MeasuresLayout(props) {
                         handleFilters={(checkboxState) => handleFilters(checkboxState, 'rLadder')}
                       />
                       <SearchFilter
-                        ref={juridischeFilterRef}
-                        title='Juridische houdbaarheid'
-                        list={juridischeHoudbaarheid}
-                        filterNumbers={[numberOfJ1, numberOfJ2, numberOfJ3, numberOfJ4, numberOfJ5]}
+                        ref={juridischHaalbaarheidFilterRef}
+                        title='Juridisch Haalbaarheid'
+                        list={juridischHaalbaarheid}
+                        filterNumbers={[
+                          numberOfJHLow, 
+                          numberOfJHMedium, 
+                          numberOfJHHigh]}
                         handleFilters={(checkboxState) =>
-                          handleFilters(checkboxState, 'juridischeHoudbaarheid')
+                          handleFilters(checkboxState, 'juridischHaalbaarheid')
                         }
                       />
                       <SearchFilter
-                        ref={subrechtsgebiedFilterRef}
-                        title='Subrechtsgebied'
-                        list={subrechtsgebied}
+                        ref={juridischInvloedFilterRef}
+                        title='Juridisch Invloed'
+                        list={juridischInvloed}
                         filterNumbers={[
-                          numberOfErp,
-                          numberOfOmg,
-                          numberOfAan,
-                          numberOfCont,
-                          numberOfGron,
-                        ]}
+                          numberOfJILow, 
+                          numberOfJIMedium, 
+                          numberOfJIHigh]}
                         handleFilters={(checkboxState) =>
-                          handleFilters(checkboxState, 'subrechtsgebied')
+                          handleFilters(checkboxState, 'juridischInvloed')
                         }
                       />
                     </div>
@@ -710,9 +802,25 @@ export default function MeasuresLayout(props) {
             ref={rechtsgebiedFilterRef}
             title='Rechtsgebied'
             list={rechtsgebied}
-            filterNumbers={[numberOfPubliek, numberOfPrivaat, numberOfFiscaal]}
+            filterNumbers={[
+              numberOfPubliek, 
+              numberOfPrivaat, 
+              numberOfFiscaal]}
             handleFilters={(checkboxState) => handleFilters(checkboxState, 'rechtsgebied')}
           />
+          <SearchFilter
+            ref={subrechtsgebiedFilterRef}
+            title='Subrechtsgebied'
+            list={subrechtsgebied}
+            filterNumbers={[
+              numberOfErp, 
+              numberOfOmg, 
+              numberOfAan, 
+              numberOfCont, 
+              numberOfGron]}
+            handleFilters={(checkboxState) => handleFilters(checkboxState, 'subrechtsgebied')}
+          />
+        
           <SearchFilter
             ref={rLadderFilterRef}
             title='R - ladder'
@@ -720,25 +828,34 @@ export default function MeasuresLayout(props) {
             filterNumbers={[numberOfR1, numberOfR2, numberOfR3, numberOfR4, numberOfR5, numberOfR6]}
             handleFilters={(checkboxState) => handleFilters(checkboxState, 'rLadder')}
           />
+          
           <SearchFilter
-            ref={juridischeFilterRef}
-            title='Juridische houdbaarheid'
-            list={juridischeHoudbaarheid}
-            filterNumbers={[numberOfJ1, numberOfJ2, numberOfJ3, numberOfJ4, numberOfJ5]}
+            ref={juridischHaalbaarheidFilterRef}
+            title='Juridisch Haalbaarheid'
+            list={juridischHaalbaarheid}
+            filterNumbers={[
+              numberOfJHLow, 
+              numberOfJHMedium, 
+              numberOfJHHigh,
+            ]}
             handleFilters={(checkboxState) =>
-              handleFilters(checkboxState, 'juridischeHoudbaarheid')
+              handleFilters(checkboxState, 'juridischHaalbaarheid')
             }
-            juridischeHoudbaarheidStyleProp='juridischeHoudbaarheidCSSClasses'
           />
           <SearchFilter
-            ref={subrechtsgebiedFilterRef}
-            title='Subrechtsgebied'
-            list={subrechtsgebied}
-            filterNumbers={[numberOfErp, numberOfOmg, numberOfAan, numberOfCont, numberOfGron]}
-            handleFilters={(checkboxState) => handleFilters(checkboxState, 'subrechtsgebied')}
+            ref={juridischInvloedFilterRef}
+            title='Juridisch Invloed'
+            list={juridischInvloed}
+            filterNumbers={[
+              numberOfJILow, 
+              numberOfJIMedium, 
+              numberOfJIHigh,
+            ]}
+            handleFilters={(checkboxState) =>
+              handleFilters(checkboxState, 'juridischInvloed')
+            }
           />
-        </div>
-
+          </div>
         <div className='mt-10 col-span-3 '>
           {data && (
             <div>

--- a/components/link-icon.js
+++ b/components/link-icon.js
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import linkIcon from '../public/icons/Vectorlink-icon.svg';
 
-
 // this should work but only after next 12.2
 const sizes = {
   mob: 'h-2 w-2',

--- a/components/measure-overview.js
+++ b/components/measure-overview.js
@@ -15,103 +15,126 @@ export default function MeasureOverview({ viewport, children, data, ...props }) 
   return (
     <div {...props} className={`${viewportClasses}`}>
       <div className='py-12 block h-[38rem]'>
-      {children}
-      <div className='container pb-2'>
-        {data?.measure?.thema === 'houtbouw' ? (
-          <div className='container-image'>
-            <Image src={IcontWood} alt='Icon of a Wood Log' />
-          </div>
-        ) : (
-          <div className='container-image'>
-            <Image src={WindmillIcon} alt='Icon of a Wood Log' />
-          </div>
-        )}
-        <div className=''>
-          <Link href={'/' + data?.measure?.thema.replace(/\s+/g, '-').toLowerCase()}>
-            <a>
-              <span className='overview-thema underline pl-2 text-green1 first-letter:uppercase block'>
-                {data?.measure?.thema}
-              </span>
-            </a>
-          </Link>
-        </div>
-      </div>
-
-      <div className='pt-5 pb-1 border-t border-grey1'>
-        <div className='flex pb-2 justify-left items-center'>
-          <span className='overview-titles text-black1 pr-3'>R-ladder</span>
-          <RTooltip>
-          <svg width="24" height="30" viewBox="0 0 24 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="12" cy="15" r="12" fill="#676868"/>
-              <path d="M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z" fill="#F8FAF8"/>
-                </svg>
-
-          </RTooltip>
-        </div>
-        <span className='block-inline grid grid-rows-1 grid-cols-6 w-4/5'>
-          {data?.measure?.rLadder.map((rValue) => (
-            <span key={rValue} className='bg-green1 text-white1 r-category rounded-full p-1 mr-2 h-8 w-8 flex justify-center items-center'>
-              {rValue}
-            </span>
-          ))}
-        </span>
-      </div>
-
-      <div className='pt-5 pb-1'>
-        <div className='relative border-t border-grey1 pt-4'>
-          <div className='overview-titles text-black1 py-2'>Subrechtsgebied</div>
-        </div>
-
-        <div className='overview-text first-letter:capitalize'>
-          <p>{data?.measure?.subrechtsgebied}</p>
-        </div>
-      </div>
-
-      <div className='pt-5 pb-1'>
-        <div className='relative flex justify-between border-t border-grey1 pt-2'>
-          <div className='flex py-2'>
-            <span className='overview-titles text-black1 py-2 pr-3'>
-              Juridisch invloed
-            </span>
-            <JITooltip data={data}>
-            <svg width="24" height="30" viewBox="0 0 24 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="12" cy="15" r="12" fill="#676868"/>
-            <path d="M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z" fill="#F8FAF8"/>
-            </svg>
-
-            </JITooltip>
+        {children}
+        <div className='container pb-2'>
+          {data?.measure?.thema === 'houtbouw' ? (
+            <div className='container-image'>
+              <Image src={IcontWood} alt='Icon of a Wood Log' />
+            </div>
+          ) : (
+            <div className='container-image'>
+              <Image src={WindmillIcon} alt='Icon of a Wood Log' />
+            </div>
+          )}
+          <div className=''>
+            <Link href={'/' + data?.measure?.thema.replace(/\s+/g, '-').toLowerCase()}>
+              <a>
+                <span className='overview-thema underline pl-2 text-green1 first-letter:uppercase block'>
+                  {data?.measure?.thema}
+                </span>
+              </a>
+            </Link>
           </div>
         </div>
 
-        <div className='flex items-center'>
-          <span className='overview-text border border-black rounded-xl uppercase px-2'>
-            {data?.measure?.juridischInvloed}
-          </span>
-        </div>
-      </div>
-
-      <div className='pt-5 pb-5 border-b border-grey1'>
-        <div className='relative flex justify-between border-t border-grey1 pt-2'>
-          <div className='flex py-2'>
-            <span className='overview-titles text-black1 py-2 pr-3'>
-              Juridisch houdbaarheid
-            </span>
-            <JHTooltip data={data}>
-            <svg width="24" height="30" viewBox="0 0 24 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="15" r="12" fill="#676868"/>
-              <path d="M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z" fill="#F8FAF8"/>
+        <div className='pt-5 pb-1 border-t border-grey1'>
+          <div className='flex pb-2 justify-left items-center'>
+            <span className='overview-titles text-black1 pr-3'>R-ladder</span>
+            <RTooltip>
+              <svg
+                width='24'
+                height='30'
+                viewBox='0 0 24 30'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <circle cx='12' cy='15' r='12' fill='#676868' />
+                <path
+                  d='M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z'
+                  fill='#F8FAF8'
+                />
               </svg>
-
-            </JHTooltip>
+            </RTooltip>
           </div>
-        </div>
-        <div className='flex items-center w-10/12'>
-          <span className='overview-text border border-black rounded-xl px-2 uppercase'>
-            {data?.measure?.juridischHaalbaarheid}
+          <span className='block-inline grid grid-rows-1 grid-cols-6 w-4/5'>
+            {data?.measure?.rLadder.map((rValue) => (
+              <span
+                key={rValue}
+                className='bg-green1 text-white1 r-category rounded-full p-1 mr-2 h-8 w-8 flex justify-center items-center'
+              >
+                {rValue}
+              </span>
+            ))}
           </span>
         </div>
+
+        <div className='pt-5 pb-1'>
+          <div className='relative border-t border-grey1 pt-4'>
+            <div className='overview-titles text-black1 py-2'>Subrechtsgebied</div>
+          </div>
+
+          <div className='overview-text first-letter:capitalize'>
+            <p>{data?.measure?.subrechtsgebied}</p>
+          </div>
+        </div>
+
+        <div className='pt-5 pb-1'>
+          <div className='relative flex justify-between border-t border-grey1 pt-2'>
+            <div className='flex py-2'>
+              <span className='overview-titles text-black1 py-2 pr-3'>Juridisch invloed</span>
+              <JITooltip data={data}>
+                <svg
+                  width='24'
+                  height='30'
+                  viewBox='0 0 24 30'
+                  fill='none'
+                  xmlns='http://www.w3.org/2000/svg'
+                >
+                  <circle cx='12' cy='15' r='12' fill='#676868' />
+                  <path
+                    d='M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z'
+                    fill='#F8FAF8'
+                  />
+                </svg>
+              </JITooltip>
+            </div>
+          </div>
+
+          <div className='flex items-center'>
+            <span className='overview-text border border-black rounded-xl uppercase px-2'>
+              {data?.measure?.juridischInvloed}
+            </span>
+          </div>
+        </div>
+
+        <div className='pt-5 pb-5 border-b border-grey1'>
+          <div className='relative flex justify-between border-t border-grey1 pt-2'>
+            <div className='flex py-2'>
+              <span className='overview-titles text-black1 py-2 pr-3'>Juridisch houdbaarheid</span>
+              <JHTooltip data={data}>
+                <svg
+                  width='24'
+                  height='30'
+                  viewBox='0 0 24 30'
+                  fill='none'
+                  xmlns='http://www.w3.org/2000/svg'
+                >
+                  <circle cx='12' cy='15' r='12' fill='#676868' />
+                  <path
+                    d='M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z'
+                    fill='#F8FAF8'
+                  />
+                </svg>
+              </JHTooltip>
+            </div>
+          </div>
+          <div className='flex items-center w-10/12'>
+            <span className='overview-text border border-black rounded-xl px-2 uppercase'>
+              {data?.measure?.juridischHaalbaarheid}
+            </span>
+          </div>
+        </div>
       </div>
-    </div>
     </div>
   );
 }

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -11,7 +11,7 @@ export default function MeasureTable({ data }) {
     <div className='grid grid-cols-6 mt-2'>
       <div className='col-span-4'>
               <div>
-              <h2 className='pt-10 pb-4 mobile sm:H2urban'>Juridische toelichting</h2>
+              <h2 className='pt-10 pb-4 mobile sm:urban'>Juridische toelichting</h2>
               {data?.measure?.juridischeToelichting && 
               <p className='newlineDisplay body-text-mobile sm:body-text pb-4'>
                 {data?.measure?.juridischeToelichting}

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -8,63 +8,69 @@ const formatDate = (date) => {
 export default function MeasureTable({ data }) {
   return (
     <>
-    <div className='grid grid-cols-6 mt-2'>
-      <div className='col-span-4'>
-              <div>
-              <h2 className='pt-10 pb-4 mobile sm:urban'>Juridische toelichting</h2>
-              {data?.measure?.juridischeToelichting && 
+      <div className='grid grid-cols-6 mt-2'>
+        <div className='col-span-4'>
+          <div>
+            <h2 className='pt-10 pb-4 mobile sm:urban'>Juridische toelichting</h2>
+            {data?.measure?.juridischeToelichting && (
               <p className='newlineDisplay body-text-mobile sm:body-text pb-4'>
                 {data?.measure?.juridischeToelichting}
-              </p>}
-              </div>
-      </div>
-      <table className='table-fixed col-span-4'>
-        <tbody>
-          <tr className='my-10 border-b boder-grey2 border-t'>
-            <td className='w-1/3 py-1.5 body-small'>Rechtsgebied</td>
-            <td className='w-2/3 py-1.5 table-right capitalize'>
-              {data?.measure?.rechtsgebied} - {data?.measure?.subrechtsgebied}
-            </td>
-          </tr>
-          <tr className=' border-b boder-grey2'>
-            <td className='w-1/3 py-1.5 body-small'>Citeertitel</td>
-            <td className='w-2/3 py-1.5 table-right first-letter:uppercase'>
-              {data?.measure?.citeertitel}
-            </td>
-          </tr>
-          <tr className='border-b boder-grey2'>
-            <td className='w-1/3 py-1.5 body-small'>Artikel</td>
-            <td className='w-2/3 py-1.5 table-right'>
-              <a
-                className='text-greenLink underline'
-                target='_blank'
-                href={data?.measure?.artikelLink}
-                rel='noreferrer'
-              >
-                {data?.measure?.artikel}
-                <span className='pl-1'>
-                  <Image alt='new tab' src='/icons/Vectorlink-icon.svg' width={13} height={13} />
-                </span>
-              </a>
-            </td>
-          </tr>
-          <tr className='border-b boder-grey2'>
-            <td className='w-1/3 py-1.5 body-small'>Geldig vanaf</td>
-            <td className='w-2/3 py-1.5 table-right'>
-              {!data?.measure?.lawDate ? <span className='table-right'>TBD</span> : formatDate(data?.measure?.lawDate)}
-            </td>
-          </tr>
-          <tr className='border-b boder-grey2'>
-            <td className='w-1/3 py-1.5 body-small'>Bevoegdheidsniveau</td>
-            <td className='w-2/3 py-1.5 table-right'>
-              {data?.measure?.governmentLevel?.map((level) => (
-                <span key={level} className='table-right capitalize'>
-                  {level} {data?.measure?.governmentLevel.slice(-1)[0] !== level && <span>- </span>}
-                </span>
-              ))}
-            </td>
-          </tr>
-          {/* DELETE 
+              </p>
+            )}
+          </div>
+        </div>
+        <table className='table-fixed col-span-4'>
+          <tbody>
+            <tr className='my-10 border-b boder-grey2 border-t'>
+              <td className='w-1/3 py-1.5 body-small'>Rechtsgebied</td>
+              <td className='w-2/3 py-1.5 table-right capitalize'>
+                {data?.measure?.rechtsgebied} - {data?.measure?.subrechtsgebied}
+              </td>
+            </tr>
+            <tr className=' border-b boder-grey2'>
+              <td className='w-1/3 py-1.5 body-small'>Citeertitel</td>
+              <td className='w-2/3 py-1.5 table-right first-letter:uppercase'>
+                {data?.measure?.citeertitel}
+              </td>
+            </tr>
+            <tr className='border-b boder-grey2'>
+              <td className='w-1/3 py-1.5 body-small'>Artikel</td>
+              <td className='w-2/3 py-1.5 table-right'>
+                <a
+                  className='text-greenLink underline'
+                  target='_blank'
+                  href={data?.measure?.artikelLink}
+                  rel='noreferrer'
+                >
+                  {data?.measure?.artikel}
+                  <span className='pl-1'>
+                    <Image alt='new tab' src='/icons/Vectorlink-icon.svg' width={13} height={13} />
+                  </span>
+                </a>
+              </td>
+            </tr>
+            <tr className='border-b boder-grey2'>
+              <td className='w-1/3 py-1.5 body-small'>Geldig vanaf</td>
+              <td className='w-2/3 py-1.5 table-right'>
+                {!data?.measure?.lawDate ? (
+                  <span className='table-right'>TBD</span>
+                ) : (
+                  formatDate(data?.measure?.lawDate)
+                )}
+              </td>
+            </tr>
+            <tr className='border-b boder-grey2'>
+              <td className='w-1/3 py-1.5 body-small'>Bevoegdheidsniveau</td>
+              <td className='w-2/3 py-1.5 table-right'>
+                {data?.measure?.governmentLevel?.map((level) => (
+                  <span key={level} className='table-right capitalize'>
+                    {level}{' '}
+                    {data?.measure?.governmentLevel.slice(-1)[0] !== level && <span>- </span>}
+                  </span>
+                ))}
+              </td>
+            </tr>
+            {/* DELETE 
             <tr className='my-10 border-b-2'>
               <td className='w-1/2 font-manrope text-base font-normal'>Type document</td>
               <td className='w-1/2 font-manrope text-base font-bold'>{data.measure?.type_document}</td>
@@ -74,8 +80,8 @@ export default function MeasureTable({ data }) {
               <td className='font-manrope text-base font-bold'>{data.measure?.type_beleidsinstrument}</td>
             </tr>
             */}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
       </div>
     </>
   );

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -11,7 +11,7 @@ export default function MeasureTable({ data }) {
     <div className='grid grid-cols-6 mt-2'>
       <div className='col-span-4'>
               <div>
-              <h2 className='pt-10 pb-4 mobile sm:urban'>Juridische toelichting</h2>
+              <h2 className='pt-10 pb-4 mobile sm:H2urban'>Juridische toelichting</h2>
               {data?.measure?.juridischeToelichting && 
               <p className='newlineDisplay body-text-mobile sm:body-text pb-4'>
                 {data?.measure?.juridischeToelichting}

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -57,7 +57,7 @@ export default function MeasureTable({ data }) {
           <tr className='border-b boder-grey2'>
             <td className='w-1/3 py-1.5 body-small'>Bevoegdheidsniveau</td>
             <td className='w-2/3 py-1.5 table-right'>
-              {data?.measure?.governmentLevel.map((level) => (
+              {data?.measure?.governmentLevel?.map((level) => (
                 <span key={level} className='table-right capitalize'>
                   {level} {data?.measure?.governmentLevel.slice(-1)[0] !== level && <span>- </span>}
                 </span>

--- a/components/policy-list.js
+++ b/components/policy-list.js
@@ -46,7 +46,8 @@ export default function PolicyList(props) {
               <div className='block font-manrope font-bold text-xs pb-1'>
                 {law?.wettelijkBevoegdheidsniveau?.map((level) => (
                   <span key={level} className='capitalize'>
-                    {level} {law?.wettelijkBevoegdheidsniveau.slice(-1)[0] !== level && <span>- </span>}
+                    {level}{' '}
+                    {law?.wettelijkBevoegdheidsniveau.slice(-1)[0] !== level && <span>- </span>}
                   </span>
                 ))}
               </div>

--- a/components/policy-list.js
+++ b/components/policy-list.js
@@ -24,7 +24,9 @@ export default function PolicyList(props) {
               {law?.thema === 'mattress' && (
                 <Image width='20' height='20' src={IconWood} alt='Icon of Wood' />
               )}
-              <span className='inline-block pl-4 font-openSans casus'>{law?.thema.replace('-', ' ')}</span>
+              <span className='inline-block pl-4 font-openSans casus'>
+                {law?.thema.replace('-', ' ')}
+              </span>
               {law?.extraContent &&
                 law?.extraContent.map((content) => (
                   <span
@@ -42,9 +44,9 @@ export default function PolicyList(props) {
                 </a>
               </Link>
               <div className='block font-manrope font-bold text-xs pb-1'>
-                {law?.governmentLevel?.map((level) => (
+                {law?.wettelijkBevoegdheidsniveau?.map((level) => (
                   <span key={level} className='capitalize'>
-                    {level} {law?.governmentLevel.slice(-1)[0] !== level && <span>- </span>}
+                    {level} {law?.wettelijkBevoegdheidsniveau.slice(-1)[0] !== level && <span>- </span>}
                   </span>
                 ))}
               </div>

--- a/components/policy-list.js
+++ b/components/policy-list.js
@@ -42,7 +42,7 @@ export default function PolicyList(props) {
                 </a>
               </Link>
               <div className='block font-manrope font-bold text-xs pb-1'>
-                {law?.governmentLevel.map((level) => (
+                {law?.governmentLevel?.map((level) => (
                   <span key={level} className='capitalize'>
                     {level} {law?.governmentLevel.slice(-1)[0] !== level && <span>- </span>}
                   </span>
@@ -67,7 +67,7 @@ export default function PolicyList(props) {
 
                 <div className='flex-2 mr-5 text-normal font-openSans text-xs text-black1 sm:text-gray-400 '>
                   <span className='block-inline flex items-center'>
-                    Juridische invloed:{' '}
+                    Juridische Haalbaarheid:{' '}
                     <span className='text-black uppercase pl-1'>{law.juridischHaalbaarheid}</span>
                   </span>
                 </div>

--- a/components/search-filter.js
+++ b/components/search-filter.js
@@ -2,11 +2,12 @@ import { useState, forwardRef, useImperativeHandle } from 'react';
 import { handleToggle } from '../utils';
 import RTooltip from '../components/r-ladder-tooltip';
 import JHTooltip from '../components/juridische-houdbaarheid-tooltip';
+import JITooltip from '../components/juridische-invloed-tooltip';
+
 
 const rLadderLabelStyles = 'bg-green2 text-white rounded-full p-1 mr-2 block-inline r-category ';
-const juridischeHoudbaarheidLabelStyles = 'my-1 mx-1 h-4 w-4 flex-shrink-0 rounded-full';
 
-const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, ref) => {
+const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, ref) => {
   const [checkedArray, setCheckedArray] = useState([]);
 
   // state to check if set value is for mouse click or state persist
@@ -31,9 +32,9 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
       // only do this for state persist and not mouse click
       if (!clicked) {
         let newArr = [];
-        for (let index = 0; index < selectedArray.length; index++) {
+        for (let index = 0; index < selectedArray?.length; index++) {
           // matching values to IDs
-          list.map((element) => {
+          list?.map((element) => {
             if (selectedArray[index] === element.value) {
               newArr.push(element.id);
             }
@@ -60,7 +61,7 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
               </svg>
             </RTooltip>
           )}
-          {title === 'Juridische houdbaarheid' && (
+          {title === 'Juridisch Haalbaarheid' && (
             <JHTooltip>
               <svg className='w-6 h-6 fill-current text-black mb-2' viewBox='0 0 26 26'>
                 <circle cx='12' cy='15' r='10' fill='#979797' />
@@ -71,10 +72,21 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
               </svg>
             </JHTooltip>
           )}
+           {title === 'Juridisch Invloed' && (
+            <JITooltip>
+              <svg className='w-6 h-6 fill-current text-black mb-2' viewBox='0 0 26 26'>
+                <circle cx='12' cy='15' r='10' fill='#979797' />
+                <path
+                  d='M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z'
+                  fill='black'
+                />
+              </svg>
+            </JITooltip>
+          )}
         </div>
       </div>
       <div>
-        {list.map((data, dataIdx) => (
+        {list?.map((data, dataIdx) => (
           <div key={dataIdx} className='relative flex justify-between'>
             {filterNumbers[dataIdx] > 0 ? (
               <>
@@ -97,24 +109,8 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
                         <span>{data.name}</span>
                       </>
                     )}
-
-                    {/* Juridische houdbaarheid */}
-                    {title === 'Juridische houdbaarheid' && (
-                      <span className='block-inline flex items-center'>
-                        {title === 'Juridische houdbaarheid' &&
-                          [0, 1, 2, 3, 4].map((rating) => (
-                            <span
-                              key={rating}
-                              className={`${
-                                data.value > rating ? 'score-true' : 'score-false'
-                              } ${juridischeHoudbaarheidLabelStyles} `}
-                              aria-hidden='true'
-                            ></span>
-                          ))}
-                      </span>
-                    )}
                     {/* std design */}
-                    {title !== 'R - ladder' && title !== 'Juridische houdbaarheid' && (
+                    {title !== 'R - ladder' && (
                       <span>{data.name}</span>
                     )}
                   </label>
@@ -144,28 +140,14 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
                       </>
                     )}
 
-                    {/* Juridische houdbaarheid */}
-                    {title === 'Juridische houdbaarheid' && (
-                      <span className='block-inline flex items-center'>
-                        {title === 'Juridische houdbaarheid' &&
-                          [0, 1, 2, 3, 4].map((rating) => (
-                            <span
-                              key={rating}
-                              className={`${
-                                data.value > rating ? 'score-true' : 'score-false'
-                              } ${juridischeHoudbaarheidLabelStyles} `}
-                              aria-hidden='true'
-                            ></span>
-                          ))}
-                      </span>
-                    )}
-
-                    {title !== 'R - ladder' && title !== 'Juridische houdbaarheid' && (
+                    {title !== 'R - ladder' && (
                       <span>{data.name}</span>
                     )}
                   </label>
                 </div>
-                <div className='font-normal text-sm text-gray-400'>({filterNumbers[dataIdx]})</div>
+                <div className='font-normal text-sm text-gray-400'>
+                  ({filterNumbers[dataIdx]})
+                  </div>
               </>
             )}
           </div>

--- a/components/search-filter.js
+++ b/components/search-filter.js
@@ -4,10 +4,9 @@ import RTooltip from '../components/r-ladder-tooltip';
 import JHTooltip from '../components/juridische-houdbaarheid-tooltip';
 import JITooltip from '../components/juridische-invloed-tooltip';
 
-
 const rLadderLabelStyles = 'bg-green2 text-white rounded-full p-1 mr-2 block-inline r-category ';
 
-const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, ref) => {
+const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, ref) => {
   const [checkedArray, setCheckedArray] = useState([]);
 
   // state to check if set value is for mouse click or state persist
@@ -32,10 +31,12 @@ const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, r
       // only do this for state persist and not mouse click
       if (!clicked) {
         let newArr = [];
-        for (let index = 0; index < selectedArray?.length; index++) {
+        for (let index = 0; index < selectedArray.length; index++) {
           // matching values to IDs
           list?.map((element) => {
+            // list = list of all the elements in dataFilter
             if (selectedArray[index] === element.value) {
+              // element = the dataFilter element
               newArr.push(element.id);
             }
           });
@@ -72,7 +73,7 @@ const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, r
               </svg>
             </JHTooltip>
           )}
-           {title === 'Juridisch Invloed' && (
+          {title === 'Juridisch Invloed' && (
             <JITooltip>
               <svg className='w-6 h-6 fill-current text-black mb-2' viewBox='0 0 26 26'>
                 <circle cx='12' cy='15' r='10' fill='#979797' />
@@ -110,9 +111,7 @@ const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, r
                       </>
                     )}
                     {/* std design */}
-                    {title !== 'R - ladder' && (
-                      <span>{data.name}</span>
-                    )}
+                    {title !== 'R - ladder' && <span>{data.name}</span>}
                   </label>
                 </div>
                 <div className='font-bold font-manrope text-sm text-black'>
@@ -140,14 +139,10 @@ const SearchFilter = forwardRef(({list, title, filterNumbers, handleFilters }, r
                       </>
                     )}
 
-                    {title !== 'R - ladder' && (
-                      <span>{data.name}</span>
-                    )}
+                    {title !== 'R - ladder' && <span>{data.name}</span>}
                   </label>
                 </div>
-                <div className='font-normal text-sm text-gray-400'>
-                  ({filterNumbers[dataIdx]})
-                  </div>
+                <div className='font-normal text-sm text-gray-400'>({filterNumbers[dataIdx]})</div>
               </>
             )}
           </div>

--- a/components/search-filter.js
+++ b/components/search-filter.js
@@ -89,7 +89,9 @@ const SearchFilter = forwardRef(({ list, title, filterNumbers, handleFilters }, 
       <div>
         {list?.map((data, dataIdx) => (
           <div key={dataIdx} className='relative flex justify-between'>
+            
             {filterNumbers[dataIdx] > 0 ? (
+              
               <>
                 <div className='my-1 block-inline flex items-center'>
                   <input

--- a/dataFilter.js
+++ b/dataFilter.js
@@ -17,12 +17,14 @@ export const wettelijkBevoegdheidsniveau = [
     label: 'Provinciaal',
     value: 'Provinciaal',
   },
+  
   {
     id: '3',
     name: 'Gemeentelijk',
     label: 'Gemeentelijk',
     value: 'Gemeentelijk',
   },
+
 ];
 
 export const rechtsgebied = [
@@ -118,35 +120,59 @@ export const rLadder = [
   },
 ];
 
-export const juridischeHoudbaarheid = [
+export const juridischHaalbaarheid = [
   {
     id: '0',
-    name: '1',
-    label: '1',
-    value: 1,
+    name: 'Low',
+    label: 'Low',
+    value: 'Low',
   },
   {
     id: '1',
-    name: '2',
-    label: '2',
-    value: 2,
+    name: 'Medium',
+    label: 'Medium',
+    value: 'Medium',
   },
   {
     id: '2',
-    name: '3',
-    label: '3',
-    value: 3,
-  },
-  {
-    id: '3',
-    name: '4',
-    label: '4',
-    value: 4,
-  },
-  {
-    id: '4',
-    name: '5',
-    label: '5',
-    value: 5,
+    name: 'High',
+    label: 'High',
+    value: 'High',
   },
 ];
+
+export const juridischInvloed = [
+  {
+    id: '0',
+    name: 'Low',
+    label: 'Low',
+    value: 'Low',
+  },
+  {
+    id: '1',
+    name: 'Medium',
+    label: 'Medium',
+    value: 'Medium',
+  },
+  {
+    id: '2',
+    name: 'High',
+    label: 'High',
+    value: 'High',
+  },
+]
+
+export const extraContent = [
+  {
+    id: '0',
+    name: 'Example',
+    label: 'Example',
+    value: 'Example',
+  },
+  {
+    id: '1',
+    name: 'Guideline',
+    label: 'Guideline',
+    value: 'Guideline',
+  }, 
+]

--- a/global.css
+++ b/global.css
@@ -14,21 +14,21 @@
   }
 
    
-  h1.urban {
+  .H1urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 600;
     font-size: 54.9px;
     line-height: 64px;
   }
 
-  h2.urban {
+  .H2urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 600;
     font-size: 28px;
     line-height: 32px;
   }
 
-  h4.urban {
+  .H4urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 500;
     font-size: 18px;

--- a/global.css
+++ b/global.css
@@ -14,21 +14,21 @@
   }
 
    
-  .H1urban {
+  h1.urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 600;
     font-size: 54.9px;
     line-height: 64px;
   }
 
-  .H2urban {
+  h2.urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 600;
     font-size: 28px;
     line-height: 32px;
   }
 
-  .H4urban {
+  h4.urban {
     font-family: 'Urbanist', 'sans-serif';
     font-weight: 500;
     font-size: 18px;

--- a/global.css
+++ b/global.css
@@ -73,7 +73,7 @@
   }
 
   h1.main {
-    font-family: 'Public Sans', 'sans-serif';
+    font-family: 'Public Sans';
     font-style: normal;
     font-weight: 700;
     font-size: 52px;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,8 +7,9 @@ export default function Document() {
         <link rel='preconnect' href='https://fonts.googleapis.com' />
         <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='true' />
         <link 
-          href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&family=Urbanist:wght@400;500;600&display=swap" 
-          rel="stylesheet" />
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&family=Public+Sans:wght@300;700;800&family=Urbanist:wght@400;500;600&display=swap" 
+            rel="stylesheet" 
+            />
         <meta name='description' content='Regelgeving voor een circulaire economie' />
         <meta property='og:title' content='CircuLaw' key='ogtitle' />
         <meta

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,10 +6,10 @@ export default function Document() {
       <Head>
         <link rel='preconnect' href='https://fonts.googleapis.com' />
         <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='true' />
-        <link 
-            href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&family=Public+Sans:wght@300;700;800&family=Urbanist:wght@400;500;600&display=swap" 
-            rel="stylesheet" 
-            />
+        <link
+          href='https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&family=Public+Sans:wght@300;700;800&family=Urbanist:wght@400;500;600&display=swap'
+          rel='stylesheet'
+        />
         <meta name='description' content='Regelgeving voor een circulaire economie' />
         <meta property='og:title' content='CircuLaw' key='ogtitle' />
         <meta

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -40,7 +40,7 @@ const components = {
   types: {
     greenBox: ({ value }) => (
       <div className='bg-green6 w-full px-6 py-8 my-14'>
-        <h2 className='pb-6 H2urban'>{value?.greenBoxTitle}</h2>
+        <h2 className='pb-6 urban'>{value?.greenBoxTitle}</h2>
         <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div>
       </div>
     ),
@@ -70,7 +70,7 @@ const components = {
           <div className='absolute -bottom-44 -right-44 h-96 w-96'>
           <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562}/>
           </div>
-          <h2 className='pb-2 mobile sm:H2urban text-white'>{value.pdfTitle}</h2>
+          <h2 className='pb-2 mobile sm:urban text-white'>{value.pdfTitle}</h2>
           <p className='body-text-mobile sm:body-text text-white1 pb-4'>{value.pdfText}</p>
           <a
             href={`https://cdn.sanity.io/files/${
@@ -88,7 +88,7 @@ const components = {
     smallPara: ({value}) => (
       <div className='flex justify-left pl-12'>
       <div className='mb-12 pt-10 w-5/6'>
-      <h4 className='H4urban'>{value.smallParaTitle}</h4>
+      <h4 className='urban'>{value.smallParaTitle}</h4>
       <p className='body-small'>{value.smallParaText}</p>
       </div>
       </div>
@@ -107,8 +107,8 @@ const components = {
     ),
   },
   block: {
-    h2: ({ children }) => <h2 className='pt-10 pb-4 mobile sm:H2urban'>{children}</h2>,
-    firstH2: ({ children }) => <h2 className='pb-8 mobile sm:H2urban'>{children}</h2>,
+    h2: ({ children }) => <h2 className='pt-10 pb-4 mobile sm:urban'>{children}</h2>,
+    firstH2: ({ children }) => <h2 className='pb-8 mobile sm:urban'>{children}</h2>,
 
     // need to add other styles here
     normal: ({ children }) => (
@@ -158,7 +158,7 @@ export default function TestMeasure({ data }) {
           )}
           </div>
           <div className='col-span-12 row-span-1'>
-             <h1 className='hidden lg:block pt-4 mb-7 H1urban'>
+             <h1 className='hidden lg:block pt-4 mb-7 urban'>
                 {data?.measure?.titel}
               </h1>
               </div>

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -10,7 +10,6 @@ import MeasureOverview from '../../components/measure-overview';
 import MeasureTable from '../../components/measure-table';
 import CustomButton from '../../components/custom-button';
 
-
 const pathsQuery = `
 *[_type == "measure" && defined(slug.current)][].slug.current
 `;
@@ -51,10 +50,19 @@ const components = {
           className='group'
           style={{ display: isInline ? 'inline-block' : 'block' }}
         >
-             <svg width="20" height="25" viewBox="0 0 24 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="12" cy="15" r="12" fill="#676868"/>
-              <path d="M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z" fill="#F8FAF8"/>
-                </svg>
+          <svg
+            width='20'
+            height='25'
+            viewBox='0 0 24 30'
+            fill='none'
+            xmlns='http://www.w3.org/2000/svg'
+          >
+            <circle cx='12' cy='15' r='12' fill='#676868' />
+            <path
+              d='M10.7031 10.0078C10.7031 9.23177 11.1354 8.84375 12 8.84375C12.8646 8.84375 13.2969 9.23177 13.2969 10.0078C13.2969 10.3776 13.1875 10.6667 12.9688 10.875C12.7552 11.0781 12.4323 11.1797 12 11.1797C11.1354 11.1797 10.7031 10.7891 10.7031 10.0078ZM13.1875 21H10.8047V12.2656H13.1875V21Z'
+              fill='#F8FAF8'
+            />
+          </svg>
           <div className='inline-block max-w-sm absolute invisible group-hover:visible z-10 py-3 px-6 bg-grey2 text-black1 tooltip-hover-text opacity-0 group-hover:opacity-100 transition tooltip'>
             {value.hoverText}
           </div>
@@ -66,33 +74,42 @@ const components = {
       const [_file, id, extension] = value.asset._ref.split('-');
       return (
         <div className='bg-green1'>
-        <div className=' gradient-pdf p-10 my-16 relative overflow-hidden'>
-          <div className='absolute -bottom-44 -right-44 h-96 w-96'>
-          <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562}/>
+          <div className=' gradient-pdf p-10 my-16 relative overflow-hidden'>
+            <div className='absolute -bottom-44 -right-44 h-96 w-96'>
+              <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
+            </div>
+            <h2 className='pb-2 mobile sm:urban text-white'>{value.pdfTitle}</h2>
+            <p className='body-text-mobile sm:body-text text-white1 pb-4'>{value.pdfText}</p>
+            <a
+              href={`https://cdn.sanity.io/files/${
+                process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
+              }/${process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'}/${id}.${extension}`}
+              target='_blank'
+              rel='noreferrer'
+            >
+              <CustomButton color='toPdf'>
+                Bekijk de leidraad &nbsp;
+                <Image
+                  src='/icons/pdf-icon.svg'
+                  width={23}
+                  height={23}
+                  alt='icon of pdf'
+                  className='ml-2'
+                />
+              </CustomButton>
+            </a>
           </div>
-          <h2 className='pb-2 mobile sm:urban text-white'>{value.pdfTitle}</h2>
-          <p className='body-text-mobile sm:body-text text-white1 pb-4'>{value.pdfText}</p>
-          <a
-            href={`https://cdn.sanity.io/files/${
-              process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
-            }/${process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'}/${id}.${extension}`}
-            target='_blank'
-            rel='noreferrer'
-          >
-            <CustomButton color='toPdf'>Bekijk de leidraad &nbsp;<Image src='/icons/pdf-icon.svg' width={23} height={23} alt= 'icon of pdf' className='ml-2'/></CustomButton>
-          </a>
-        </div>
         </div>
       );
     },
-    smallPara: ({value}) => (
+    smallPara: ({ value }) => (
       <div className='flex justify-left pl-12'>
-      <div className='mb-12 pt-10 w-5/6'>
-      <h4 className='urban'>{value.smallParaTitle}</h4>
-      <p className='body-small'>{value.smallParaText}</p>
+        <div className='mb-12 pt-10 w-5/6'>
+          <h4 className='urban'>{value.smallParaTitle}</h4>
+          <p className='body-small'>{value.smallParaText}</p>
+        </div>
       </div>
-      </div>
-    )
+    ),
   },
   list: {
     bullet: ({ children }) => (
@@ -126,7 +143,7 @@ const components = {
             rel='noreferrer'
           >
             {children}
-           <LinkIcon />
+            <LinkIcon />
           </a>
         </>
       ) : (
@@ -142,40 +159,33 @@ export default function TestMeasure({ data }) {
     <Layout>
       <div className='measure-bg'>
         <div className='global-margin pt-10 overflow-x-hidden'>
-
-
           <div className='grid grid-cols-12 content-center'>
-          <div className='col-span-12 row-span-1 h-12 mt-4'>
-          {/* BREADCRUMB */}
-          {data?.measure?.thema === 'houtbouw' ? (
-            <Link href='/measures/houtbouw' className=''>
-              <a className='breadcrumb'>{'<'} Terug</a>
-            </Link>
-          ) : (
-            <Link href='/measures/windturbines' className=''>
-              <a className='text-greenLink breadcrumb flex col-span-12'>← Terug</a>
-            </Link>
-          )}
-          </div>
-          <div className='col-span-12 row-span-1'>
-             <h1 className='hidden lg:block pt-4 mb-7 urban'>
-                {data?.measure?.titel}
-              </h1>
-              </div>
-              <div className='col-span-7 row-span-1'>
-              <p className='subheading py-4 mb-7'>
-                {data?.measure?.subtitle}
-              </p>
-              </div>
+            <div className='col-span-12 row-span-1 h-12 mt-4'>
+              {/* BREADCRUMB */}
+              {data?.measure?.thema === 'houtbouw' ? (
+                <Link href='/measures/houtbouw' className=''>
+                  <a className='breadcrumb'>{'<'} Terug</a>
+                </Link>
+              ) : (
+                <Link href='/measures/windturbines' className=''>
+                  <a className='text-greenLink breadcrumb flex col-span-12'>← Terug</a>
+                </Link>
+              )}
+            </div>
+            <div className='col-span-12 row-span-1'>
+              <h1 className='hidden lg:block pt-4 mb-7 urban'>{data?.measure?.titel}</h1>
+            </div>
+            <div className='col-span-7 row-span-1'>
+              <p className='subheading py-4 mb-7'>{data?.measure?.subtitle}</p>
+            </div>
           </div>
 
           <div className='grid grid-cols-1 sm:grid-cols-3 '>
-
             <div className='w-full sm:max-w-3xl pb-20 col-span-2 '>
               <div className='py-4 m'>
                 <PortableText value={data?.measure?.content} components={components} />
                 {}
-              </div>              
+              </div>
               <MeasureTable data={data} />
             </div>
             <MeasureOverview data={data} viewport='mobile' />

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -40,7 +40,7 @@ const components = {
   types: {
     greenBox: ({ value }) => (
       <div className='bg-green6 w-full px-6 py-8 my-14'>
-        <h2 className='pb-6 urban'>{value?.greenBoxTitle}</h2>
+        <h2 className='pb-6 H2urban'>{value?.greenBoxTitle}</h2>
         <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div>
       </div>
     ),
@@ -70,7 +70,7 @@ const components = {
           <div className='absolute -bottom-44 -right-44 h-96 w-96'>
           <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562}/>
           </div>
-          <h2 className='pb-2 mobile sm:urban text-white'>{value.pdfTitle}</h2>
+          <h2 className='pb-2 mobile sm:H2urban text-white'>{value.pdfTitle}</h2>
           <p className='body-text-mobile sm:body-text text-white1 pb-4'>{value.pdfText}</p>
           <a
             href={`https://cdn.sanity.io/files/${
@@ -88,7 +88,7 @@ const components = {
     smallPara: ({value}) => (
       <div className='flex justify-left pl-12'>
       <div className='mb-12 pt-10 w-5/6'>
-      <h4 className='urban'>{value.smallParaTitle}</h4>
+      <h4 className='H4urban'>{value.smallParaTitle}</h4>
       <p className='body-small'>{value.smallParaText}</p>
       </div>
       </div>
@@ -107,8 +107,8 @@ const components = {
     ),
   },
   block: {
-    h2: ({ children }) => <h2 className='pt-10 pb-4 mobile sm:urban'>{children}</h2>,
-    firstH2: ({ children }) => <h2 className='pb-8 mobile sm:urban'>{children}</h2>,
+    h2: ({ children }) => <h2 className='pt-10 pb-4 mobile sm:H2urban'>{children}</h2>,
+    firstH2: ({ children }) => <h2 className='pb-8 mobile sm:H2urban'>{children}</h2>,
 
     // need to add other styles here
     normal: ({ children }) => (
@@ -158,7 +158,7 @@ export default function TestMeasure({ data }) {
           )}
           </div>
           <div className='col-span-12 row-span-1'>
-             <h1 className='hidden lg:block pt-4 mb-7 urban'>
+             <h1 className='hidden lg:block pt-4 mb-7 H1urban'>
                 {data?.measure?.titel}
               </h1>
               </div>

--- a/pages/measures/windturbines.js
+++ b/pages/measures/windturbines.js
@@ -7,7 +7,7 @@ const lawsQuery = `
 *[_type == "measure" && thema == "circulaire-windturbines"]
 `;
 
-export default function Measures({laws}) {
+export default function Measures({ laws }) {
   return (
     <Layout>
       <MeasuresLayout

--- a/studio/schemas/measure.js
+++ b/studio/schemas/measure.js
@@ -149,11 +149,11 @@ export default {
         validaton: Rule => Rule.required(),
         options: {
           list: [
-            {title: 'Erfpacht', value: 'erfpacht'},
-            {title: 'Omgevingsrecht', value: 'omgevingsrecht'},
-            {title: 'Aanbesteding', value: 'aanbesteding'},
-            {title: 'Contracten', value: 'contracten'},
-            {title: 'Gronduitgifte', value: 'gronduitgifte'},
+            {title: 'Erfpacht', value: 'Erfpacht'},
+            {title: 'Omgevingsrecht', value: 'Omgevingsrecht'},
+            {title: 'Aanbesteding', value: 'Aanbesteding'},
+            {title: 'Contracten', value: 'Contracten'},
+            {title: 'Gronduitgifte', value: 'Gronduitgifte'},
           ],
           layout: 'dropdown'
         },
@@ -167,9 +167,9 @@ export default {
         validation: Rule => Rule.required(),
         options: {
           list: [
-            {title: 'Low', value: 'low'},
-            {title: 'Medium', value: 'medium'},
-            {title: 'High', value: 'high'},
+            {title: 'Low', value: 'Low'},
+            {title: 'Medium', value: 'Medium'},
+            {title: 'High', value: 'High'},
           ],
           layout: 'radio',
           direction: 'horizontal'
@@ -184,9 +184,9 @@ export default {
         validation: Rule => Rule.required(),
         options: {
           list: [
-            {title: 'Low', value: 'low'},
-            {title: 'Medium', value: 'medium'},
-            {title: 'High', value: 'high'},
+            {title: 'Low', value: 'Low'},
+            {title: 'Medium', value: 'Medium'},
+            {title: 'High', value: 'High'},
           ],
           layout: 'radio',
           direction: 'horizontal',
@@ -194,19 +194,18 @@ export default {
         group: ['overview', 'filter']
       },
       {
-        title: 'Government Level',
-        name: 'governmentLevel',
+        title: 'Wettelijk Bevoegdheidsniveau',
+        name: 'wettelijkBevoegdheidsniveau',
         type: 'array',
         description: 'Please select one or more levels of government',
         of: [{type: 'string'}],
         validation: Rule => Rule.required(),
         options: {
           list: [
-            {title: 'Europees', value: 'europees'},
-            {title: 'Nationaal', value: 'nationaal'},
-            {title: 'Provinciaal', value:'provinciaal'},
-            {title: 'Waterschappen', value: 'waterschappen'},
-            {title: 'Gemeentelijk', value:'gemeentelijk'},
+            {title: 'Europees', value: 'Europees'},
+            {title: 'Nationaal', value: 'Nationaal'},
+            {title: 'Provinciaal', value:'Provinciaal'},
+            {title: 'Gemeentelijk', value:'Gemeentelijk'},
           ],
           layout: 'grid',
         },
@@ -220,9 +219,9 @@ export default {
         validation: Rule => Rule.required(),
         options: {
           list: [
-            {title: 'Privaatrecht', value: 'privaatrecht'},
-            {title: 'Publiekrecht', value: 'publiekrecht'},
-            {title: 'Fiscaalrecht', value: 'fiscaalrecht'},
+            {title: 'Privaatrecht', value: 'Privaatrecht'},
+            {title: 'Publiekrecht', value: 'Publiekrecht'},
+            {title: 'Fiscaalrecht', value: 'Fiscaalrecht'},
           ],
           layout: 'radio',
           direction: 'horizontal'
@@ -237,8 +236,8 @@ export default {
         of: [{type: 'string'}],
         options: {
           list: [
-            {title: 'Example', value: 'example'},
-            {title: 'Guideline', value: 'guideline'},
+            {title: 'Example', value: 'Example'},
+            {title: 'Guideline', value: 'Guideline'},
           ],
           layout: 'grid',
         },

--- a/utils.js
+++ b/utils.js
@@ -22,3 +22,4 @@ export const handleToggle = (checkboxId, previousState) => {
   }
   return newCheckedArray.sort((a, b) => a - b);
 };
+


### PR DESCRIPTION
I linked up the filters to the CMS. Got it working no problem with the existing logic (see extra content/wettelijkBevoegdheidsniveau) and made another logic for the r values which expands rather than reduces the number of measures on display. 
Still not 100% sure on what we are looking for here. It is almost like if the first filter selected is an r value - perform a certain logic, if not - perform a different logic.

Added the content of portable text as plain text to fuse js search - now we are searching through all text where as before we were only searching a part of it. 
