### PR TITLE
Add new styles to measure page design

### DIFF
--- a/components/layouts/samenhang-layout.js
+++ b/components/layouts/samenhang-layout.js
@@ -33,12 +33,12 @@ export default function SamenhangLayout(props) {
       </div>
       <div className='global-margin mb-20'>
         <div className='max-w-3xl mx-auto'>
-          <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
+          <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p1}</p>
           {props.p2 !== '' && (
-            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
+            <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p2}</p>
           )}
           {props.p3 !== '' && (
-            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
+            <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p3}</p>
           )}
         </div>
       </div>

--- a/components/layouts/samenhang-layout.js
+++ b/components/layouts/samenhang-layout.js
@@ -33,12 +33,12 @@ export default function SamenhangLayout(props) {
       </div>
       <div className='global-margin mb-20'>
         <div className='max-w-3xl mx-auto'>
-          <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
+          <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
           {props.p2 !== '' && (
-            <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
+            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
           )}
           {props.p3 !== '' && (
-            <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
+            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
           )}
         </div>
       </div>

--- a/components/layouts/theme-index-layout.js
+++ b/components/layouts/theme-index-layout.js
@@ -21,7 +21,7 @@ export default function ThemeLayout(props) {
                 <h1 className='text-black-white-200 inline-block mobile sm:desktop'>{props.title} CF </h1>
               </div>
               <div className='col-span-7'>
-                <p className='pt-4 text-black-white-200 body-text-mobile sm:body-text'>
+                <p className='pt-4 text-black-white-200 p-mobile-bg sm:body-text'>
                   We kunnen veel milieuvriendelijker bouwen wanneer we beton (deels) vervangen door
                   houtfont change
                   <span className='text-greenLink link-mobile sm:link inline-block pl-1'>

--- a/components/layouts/theme-index-layout.js
+++ b/components/layouts/theme-index-layout.js
@@ -21,7 +21,7 @@ export default function ThemeLayout(props) {
                 <h1 className='text-black-white-200 inline-block mobile sm:desktop'>{props.title} CF </h1>
               </div>
               <div className='col-span-7'>
-                <p className='pt-4 text-black-white-200 p-mobile-bg sm:body-text'>
+                <p className='pt-4 text-black-white-200 p-mobile-bg sm:p-desktop-bg'>
                   We kunnen veel milieuvriendelijker bouwen wanneer we beton (deels) vervangen door
                   houtfont change
                   <span className='text-greenLink link-mobile sm:link inline-block pl-1'>

--- a/components/layouts/theme-index-layout.js
+++ b/components/layouts/theme-index-layout.js
@@ -40,7 +40,7 @@ export default function ThemeLayout(props) {
       <div className=''>
         <div className='global-margin'>
           {/* CREATE COMPONENT */}
-          <div classname='bg-black-white-200'>
+          <div className='bg-black-white-200'>
             <div className='pt-20'>
               <h2 className='mobile sm:desktop'>Overzichten van instrumenten die houtbouw stimuleren </h2>
             </div>

--- a/components/layouts/welke-layout.js
+++ b/components/layouts/welke-layout.js
@@ -33,15 +33,15 @@ export default function WelkeLayout(props) {
       </div>
       <div className='global-margin mb-20'>
         <div className='max-w-3xl mx-auto'>
-          <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
+          <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p1}</p>
           {props.p2 !== '' && (
-            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
+            <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p2}</p>
           )}
           {props.p3 !== '' && (
-            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
+            <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p3}</p>
           )}
           {props.p4 !== '' && (
-            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p4}</p>
+            <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6'>{props.p4}</p>
           )}
         </div>
       </div>

--- a/components/layouts/welke-layout.js
+++ b/components/layouts/welke-layout.js
@@ -33,15 +33,15 @@ export default function WelkeLayout(props) {
       </div>
       <div className='global-margin mb-20'>
         <div className='max-w-3xl mx-auto'>
-          <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
+          <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p1}</p>
           {props.p2 !== '' && (
-            <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
+            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p2}</p>
           )}
           {props.p3 !== '' && (
-            <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
+            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p3}</p>
           )}
           {props.p4 !== '' && (
-            <p className='body-text-mobile sm:body-text text-black-white-800 pb-6'>{props.p4}</p>
+            <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6'>{props.p4}</p>
           )}
         </div>
       </div>

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -28,7 +28,7 @@ export default function MeasureTable({ data }) {
       <div className='grid grid-cols-6'>
         <div className='col-span-6 sm:col-span-4'>
           <div className='pb-5'>
-            <h2 className='pt-6 pb-4 mobile sm:desktop'>Juridische toelichting</h2>
+            <h3 className='pt-6 pb-4 mobile sm:desktop'>Juridische toelichting</h3>
             {data?.measure?.juridischeToelichting && (
               <PortableText components={components} value={data?.measure?.juridischeToelichting} />
             )}

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -9,7 +9,7 @@ const formatDate = (date) => {
 const components = {
   list: {
     bullet: ({ children }) => (
-      <div className='newlineDisplay body-text-mobile sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
         <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul>
       </div>
     ),
@@ -17,7 +17,7 @@ const components = {
   block: {
     // need to add other styles here
     normal: ({ children }) => (
-      <p className='newlineDisplay body-text-mobile sm:body-text pb-4'>{children}</p>
+      <p className='newlineDisplay p-mobile-bg sm:body-text pb-4'>{children}</p>
     ),
   },
 };

--- a/components/measure-table.js
+++ b/components/measure-table.js
@@ -9,7 +9,7 @@ const formatDate = (date) => {
 const components = {
   list: {
     bullet: ({ children }) => (
-      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:p-desktop-bg truncate'>
         <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul>
       </div>
     ),
@@ -17,7 +17,7 @@ const components = {
   block: {
     // need to add other styles here
     normal: ({ children }) => (
-      <p className='newlineDisplay p-mobile-bg sm:body-text pb-4'>{children}</p>
+      <p className='newlineDisplay p-mobile-bg sm:p-desktop-bg pb-4'>{children}</p>
     ),
   },
 };

--- a/components/section-action-panel.js
+++ b/components/section-action-panel.js
@@ -8,7 +8,7 @@ export default function ActionPanel(props) {
         <h3 className='mobile sm:desktop text-black-white-200'>{props.title}</h3>
         <div className=''>
           <div>
-            <div className='mt-2 max-w-xl body-text-mobile sm:body-text text-black-white-200'>
+            <div className='mt-2 max-w-xl p-mobile-bg sm:body-text text-black-white-200'>
               {props.paragraph}
             </div>
           </div>

--- a/components/section-action-panel.js
+++ b/components/section-action-panel.js
@@ -8,7 +8,7 @@ export default function ActionPanel(props) {
         <h3 className='mobile sm:desktop text-black-white-200'>{props.title}</h3>
         <div className=''>
           <div>
-            <div className='mt-2 max-w-xl p-mobile-bg sm:body-text text-black-white-200'>
+            <div className='mt-2 max-w-xl p-mobile-bg sm:p-desktop-bg text-black-white-200'>
               {props.paragraph}
             </div>
           </div>

--- a/components/section-bottom-theme-index.js
+++ b/components/section-bottom-theme-index.js
@@ -42,7 +42,7 @@ export default function ThemeBottomSection({ props }) {
                   </div>
 
                   <h3 className='pt-6 mobile sm:desktop'>{measure.titel}</h3>
-                  <p className='body-text-mobile sm:body-new py-3 max-w-2xl'>
+                  <p className='p-mobile-bg sm:body-new py-3 max-w-2xl'>
                     {measure.introText}
                   </p>
                   <div className='flex justify-between pt-20'>

--- a/components/section-types-list.js
+++ b/components/section-types-list.js
@@ -128,7 +128,7 @@ export default function SectionTypes(props) {
                 <p
                   className={classNames(
                     props.type === 'home' ? 'h-[18rem]' : '',
-                    'body-text-mobile sm:card-body block text-black pointer-events-none py-4 w-full',
+                    'p-mobile-bg sm:card-body block text-black pointer-events-none py-4 w-full',
                   )}
                 >
                   {file.description}

--- a/pages/404/index.js
+++ b/pages/404/index.js
@@ -6,11 +6,11 @@ export default function NotFound() {
     <Layout>
       <div className='global-margin my-20 max-w-2xl text-center'>
         <h1 className='text-9xl text-black-white-800 pb-2 text-green-400'>404</h1>
-        <p className='body-text-mobile sm:body-text text-black-white-800'>
+        <p className='p-mobile-bg sm:body-text text-black-white-800'>
           We kunnen de pagina die je zoekt niet vinden. Kunnen we je verder helpen?
         </p>
 
-        <p className='body-text-mobile sm:body-text text-black-white-800'>
+        <p className='p-mobile-bg sm:body-text text-black-white-800'>
           Zoek verder:
           <ul className=''>
             <li className='text-greenLink link-mobile sm:link'>

--- a/pages/404/index.js
+++ b/pages/404/index.js
@@ -6,11 +6,11 @@ export default function NotFound() {
     <Layout>
       <div className='global-margin my-20 max-w-2xl text-center'>
         <h1 className='text-9xl text-black-white-800 pb-2 text-green-400'>404</h1>
-        <p className='p-mobile-bg sm:body-text text-black-white-800'>
+        <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800'>
           We kunnen de pagina die je zoekt niet vinden. Kunnen we je verder helpen?
         </p>
 
-        <p className='p-mobile-bg sm:body-text text-black-white-800'>
+        <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800'>
           Zoek verder:
           <ul className=''>
             <li className='text-greenLink link-mobile sm:link'>

--- a/pages/about/[slug].js
+++ b/pages/about/[slug].js
@@ -25,7 +25,7 @@ const components = {
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
           <h2 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h2>
-          <div className='p-mobile-bg sm:body-text'>{value?.greenBoxText}</div>
+          <div className='p-mobile-bg sm:p-desktop-bg'>{value?.greenBoxText}</div>
         </div>
       </div>
     ),
@@ -67,7 +67,7 @@ const components = {
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
               <h2 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h2>
-              <p className='p-mobile-bg sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p>
+              <p className='p-mobile-bg sm:p-desktop-bg text-black-white-200 pb-4'>{value.pdfText}</p>
               <a
                 href={`https://cdn.sanity.io/files/${
                   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
@@ -102,12 +102,12 @@ const components = {
   },
   list: {
     bullet: ({ children }) => (
-      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:p-desktop-bg truncate'>
         <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul>
       </div>
     ),
     number: ({ children }) => (
-      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:p-desktop-bg truncate'>
         <ol className='list-decimal pl-6 pb-4 mobile sm:main'>{children}</ol>
       </div>
     ),
@@ -122,7 +122,7 @@ const components = {
     h3: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>,
     // need to add other styles here
     normal: ({ children }) => (
-      <p className='newlineDisplay p-mobile-bg sm:body-text py-2'>{children}</p>
+      <p className='newlineDisplay p-mobile-bg sm:p-desktop-bg py-2'>{children}</p>
     ),
   },
   marks: {

--- a/pages/about/[slug].js
+++ b/pages/about/[slug].js
@@ -25,7 +25,7 @@ const components = {
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
           <h2 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h2>
-          <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div>
+          <div className='p-mobile-bg sm:body-text'>{value?.greenBoxText}</div>
         </div>
       </div>
     ),
@@ -67,7 +67,7 @@ const components = {
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
               <h2 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h2>
-              <p className='body-text-mobile sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p>
+              <p className='p-mobile-bg sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p>
               <a
                 href={`https://cdn.sanity.io/files/${
                   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
@@ -95,19 +95,19 @@ const components = {
       <div className='flex justify-left pl-8 sm:pl-12'>
         <div className='mb-10 pt-10 w-5/6'>
           <h4 className='mobile sm:desktop'>{value.smallParaTitle}</h4>
-          <p className='body-text-mobile sm:body-small'>{value.smallParaText}</p>
+          <p className='p-mobile-bg sm:body-small'>{value.smallParaText}</p>
         </div>
       </div>
     ),
   },
   list: {
     bullet: ({ children }) => (
-      <div className='newlineDisplay body-text-mobile sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
         <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul>
       </div>
     ),
     number: ({ children }) => (
-      <div className='newlineDisplay body-text-mobile sm:body-text truncate'>
+      <div className='newlineDisplay p-mobile-bg sm:body-text truncate'>
         <ol className='list-decimal pl-6 pb-4 mobile sm:main'>{children}</ol>
       </div>
     ),
@@ -122,7 +122,7 @@ const components = {
     h3: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>,
     // need to add other styles here
     normal: ({ children }) => (
-      <p className='newlineDisplay body-text-mobile sm:body-text py-2'>{children}</p>
+      <p className='newlineDisplay p-mobile-bg sm:body-text py-2'>{children}</p>
     ),
   },
   marks: {

--- a/pages/alpha/index.js
+++ b/pages/alpha/index.js
@@ -6,13 +6,13 @@ export default function Alpha() {
     <Layout>
       <div className='global-margin my-20'>
         <h1 className='mobile sm:main text-black-white-800 pb-2'>Testversie CircuLaw</h1>
-        <p className='body-text-mobile sm:body-text text-black-white-800 pb-6  max-w-2xl'>
+        <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6  max-w-2xl'>
           Welkom bij CircuLaw. Deze website is volop in ontwikkeling. In deze versie testen we de
           techniek, opzet en inhoud van de site. Het is mogelijk dat de inhoud van de site
           incompleet is of fouten bevat. Dat betekent dan ook dat aan de inhoud van deze site geen
           rechten kunnen worden ontleend.
         </p>
-        <p className='body-text-mobile sm:body-text text-black-white-800 pb-6  max-w-2xl'>
+        <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6  max-w-2xl'>
           We horen graag wat je ervan vindt, wat je anders zou willen, wat je mist en natuurlijk
           horen we ook graag waar je blij van wordt.
         </p>

--- a/pages/alpha/index.js
+++ b/pages/alpha/index.js
@@ -6,13 +6,13 @@ export default function Alpha() {
     <Layout>
       <div className='global-margin my-20'>
         <h1 className='mobile sm:main text-black-white-800 pb-2'>Testversie CircuLaw</h1>
-        <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6  max-w-2xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6  max-w-2xl'>
           Welkom bij CircuLaw. Deze website is volop in ontwikkeling. In deze versie testen we de
           techniek, opzet en inhoud van de site. Het is mogelijk dat de inhoud van de site
           incompleet is of fouten bevat. Dat betekent dan ook dat aan de inhoud van deze site geen
           rechten kunnen worden ontleend.
         </p>
-        <p className='p-mobile-bg sm:body-text text-black-white-800 pb-6  max-w-2xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg text-black-white-800 pb-6  max-w-2xl'>
           We horen graag wat je ervan vindt, wat je anders zou willen, wat je mist en natuurlijk
           horen we ook graag waar je blij van wordt.
         </p>

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -71,19 +71,19 @@ export default function Contact() {
           <>
             <h1 className='text-green-600 pt-10 mobile sm:main'>Contact</h1>
             {showPrivacyError && (
-              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-2 max-w-2xl text-red-600'>
                 Ga akkoord met de privacyvoorwaarden om te kunnen verzenden
               </p>
             )}
 
             {showEmailError && (
-              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-2 max-w-2xl text-red-600'>
                 Vul een geldig e-mail adres in
               </p>
             )}
 
             {showTextError && (
-              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-2 max-w-2xl text-red-600'>
                 Vul een vraag of opmerking in
               </p>
             )}
@@ -209,7 +209,7 @@ export default function Contact() {
         ) : (
           <>
             <h1 className='text-green-600 pt-10 mobile sm:main'>Bedankt!</h1>
-            <p className='p-mobile-bg sm:body-text py-10 max-w-2xl text-black-white-800'>
+            <p className='p-mobile-bg sm:p-desktop-bg py-10 max-w-2xl text-black-white-800'>
               Bedankt voor je bericht. We nemen zo snel mogelijk contact met je op.
             </p>
             <div className='sm:col-span-2 pb-20'>

--- a/pages/contact/index.js
+++ b/pages/contact/index.js
@@ -71,19 +71,19 @@ export default function Contact() {
           <>
             <h1 className='text-green-600 pt-10 mobile sm:main'>Contact</h1>
             {showPrivacyError && (
-              <p className='body-text-mobile sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
                 Ga akkoord met de privacyvoorwaarden om te kunnen verzenden
               </p>
             )}
 
             {showEmailError && (
-              <p className='body-text-mobile sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
                 Vul een geldig e-mail adres in
               </p>
             )}
 
             {showTextError && (
-              <p className='body-text-mobile sm:body-text py-2 max-w-2xl text-red-600'>
+              <p className='p-mobile-bg sm:body-text py-2 max-w-2xl text-red-600'>
                 Vul een vraag of opmerking in
               </p>
             )}
@@ -209,7 +209,7 @@ export default function Contact() {
         ) : (
           <>
             <h1 className='text-green-600 pt-10 mobile sm:main'>Bedankt!</h1>
-            <p className='body-text-mobile sm:body-text py-10 max-w-2xl text-black-white-800'>
+            <p className='p-mobile-bg sm:body-text py-10 max-w-2xl text-black-white-800'>
               Bedankt voor je bericht. We nemen zo snel mogelijk contact met je op.
             </p>
             <div className='sm:col-span-2 pb-20'>

--- a/pages/cookie-info/index.js
+++ b/pages/cookie-info/index.js
@@ -6,17 +6,17 @@ export default function Privacy() {
       <div className='global-margin my-20 max-w-2xl text-black-white-800'>
         <h1 className='mobile sm:main pb-6'>Cookies Info</h1>
         <h2 className='mobile sm:main py-2'>Hoe gaan we om met cookies?</h2>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Een cookie is een klein tekstbestand dat onzichtbaar is voor de gebruiker en dat de
           browser opslaat op de computer of het mobiele apparaat van de gebruiker wanneer de
           gebruiker een website bezoekt.
         </p>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Op grond van artikel 11.7a van de Telecommunicatiewet (Tw) moeten de bezoekers van de
           website geïnformeerd worden over en toestemming geven voor het plaatsen en/of uitlezen van
           cookies op hun apparaat (zoals hun computer, laptop of smartphone).
         </p>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Er zijn uitzonderingen op het toestemmingsvereiste. Bijvoorbeeld als de cookies technisch
           noodzakelijk zijn om de website goed te laten werken. Dit noemen we functionele cookies.
           Ook is er een uitzondering voor bepaalde analytische cookies. Er is bijvoorbeeld geen
@@ -24,7 +24,7 @@ export default function Privacy() {
           gebruikt worden om bezoekers te tellen. Met analytische cookies krijgen wij beter inzicht
           in het functioneren van onze website.
         </p>
-        <p className='body-text-mobile sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
           We are using{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a target='_blank' href='https://www.hotjar.com/' rel='noopener noreferrer'>
@@ -36,7 +36,7 @@ export default function Privacy() {
         </p>
 
         <h2 className='mobile sm:main py-2'>Cookies used</h2>
-        <ul className='list-disc pl-6 body-text-mobile sm:body-text max-w-4xl pb-6'>
+        <ul className='list-disc pl-6 p-mobile-bg sm:body-text max-w-4xl pb-6'>
           <li>_localConsent: Saves your cookie preference, expires in 1 year</li>
           <li>_hjSessionUser: Set when a user first lands on a page, expires in 1 year</li>
           <li>_hjSession: Holds current session data, expires in 30 mins</li>
@@ -46,7 +46,7 @@ export default function Privacy() {
             expires in 1 year
           </li>
         </ul>
-        <p className='body-text-mobile sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
           For more info you can read{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a
@@ -61,7 +61,7 @@ export default function Privacy() {
         </p>
 
         <h2 className='mobile sm:main py-2'>Wijziging van deze Privacyverklaring</h2>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           De gemeente Amsterdam heeft het recht om haar Privacyverklaring te wijzigen. Als er
           inhoudelijke wijzigingen worden doorgevoerd, maken we dit bekend via de website{' '}
           <span className='text-greenLink link-mobile sm:link'>
@@ -71,7 +71,7 @@ export default function Privacy() {
           </span>
           .{' '}
         </p>
-        <p className='body-text-mobile sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
           Heb je vragen naar aanleiding van deze Privacyverklaring? Mail ons dan op{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>

--- a/pages/cookie-info/index.js
+++ b/pages/cookie-info/index.js
@@ -6,17 +6,17 @@ export default function Privacy() {
       <div className='global-margin my-20 max-w-2xl text-black-white-800'>
         <h1 className='mobile sm:main pb-6'>Cookies Info</h1>
         <h2 className='mobile sm:main py-2'>Hoe gaan we om met cookies?</h2>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Een cookie is een klein tekstbestand dat onzichtbaar is voor de gebruiker en dat de
           browser opslaat op de computer of het mobiele apparaat van de gebruiker wanneer de
           gebruiker een website bezoekt.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Op grond van artikel 11.7a van de Telecommunicatiewet (Tw) moeten de bezoekers van de
           website geïnformeerd worden over en toestemming geven voor het plaatsen en/of uitlezen van
           cookies op hun apparaat (zoals hun computer, laptop of smartphone).
         </p>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Er zijn uitzonderingen op het toestemmingsvereiste. Bijvoorbeeld als de cookies technisch
           noodzakelijk zijn om de website goed te laten werken. Dit noemen we functionele cookies.
           Ook is er een uitzondering voor bepaalde analytische cookies. Er is bijvoorbeeld geen
@@ -24,7 +24,7 @@ export default function Privacy() {
           gebruikt worden om bezoekers te tellen. Met analytische cookies krijgen wij beter inzicht
           in het functioneren van onze website.
         </p>
-        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:p-desktop-bg max-w-4xl pb-6'>
           We are using{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a target='_blank' href='https://www.hotjar.com/' rel='noopener noreferrer'>
@@ -36,7 +36,7 @@ export default function Privacy() {
         </p>
 
         <h2 className='mobile sm:main py-2'>Cookies used</h2>
-        <ul className='list-disc pl-6 p-mobile-bg sm:body-text max-w-4xl pb-6'>
+        <ul className='list-disc pl-6 p-mobile-bg sm:p-desktop-bg max-w-4xl pb-6'>
           <li>_localConsent: Saves your cookie preference, expires in 1 year</li>
           <li>_hjSessionUser: Set when a user first lands on a page, expires in 1 year</li>
           <li>_hjSession: Holds current session data, expires in 30 mins</li>
@@ -46,7 +46,7 @@ export default function Privacy() {
             expires in 1 year
           </li>
         </ul>
-        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:p-desktop-bg max-w-4xl pb-6'>
           For more info you can read{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a
@@ -61,7 +61,7 @@ export default function Privacy() {
         </p>
 
         <h2 className='mobile sm:main py-2'>Wijziging van deze Privacyverklaring</h2>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           De gemeente Amsterdam heeft het recht om haar Privacyverklaring te wijzigen. Als er
           inhoudelijke wijzigingen worden doorgevoerd, maken we dit bekend via de website{' '}
           <span className='text-greenLink link-mobile sm:link'>
@@ -71,7 +71,7 @@ export default function Privacy() {
           </span>
           .{' '}
         </p>
-        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:p-desktop-bg max-w-4xl pb-6'>
           Heb je vragen naar aanleiding van deze Privacyverklaring? Mail ons dan op{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Wat is CircuLaw?</h2>
-              <p className='body-text-mobile sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
                 CircuLaw is een service waarmee we in de eerste plaats beleidsmakers en
                 transitiemanagers helpen meer en beter gebruik te maken van regelgeving om de
                 circulaire economie te bevorderen. Maar CircuLaw is ambitieus. Door stap voor stap
@@ -46,7 +46,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Waarom CircuLaw?</h2>
-              <p className='body-text-mobile sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
                 Voor het tegengaan van klimaatverandering, het verminderen van vervuiling, het
                 behoud van biodiversiteit en de beschikbaarheid van grondstoffen is een circulaire
                 economie essentieel. In Nederland hebben we hierin nog een lange weg te gaan. De
@@ -68,7 +68,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Hoever zijn we?</h2>
-              <ul className='body-text-mobile sm:body-text py-5 max-w-4xl list-disc pl-6'>
+              <ul className='p-mobile-bg sm:body-text py-5 max-w-4xl list-disc pl-6'>
                 <li>
                   Een overzicht van wet- en regelgeving voor beleidsmakers die aan de slag willen
                   met maatregelen voor de thema’s houtbouw en circulaire windmolens
@@ -91,7 +91,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Wie maken CircuLaw?</h2>
-              <p className='body-text-mobile sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
                 Gemeente Amsterdam, Dark Matter Laboratories, EIT Climate KIC, de Provincies
                 Noord-Holland en Flevoland, Rijksdienst voor Ondernemend Nederland (RVO), het MRA
                 (Metropoolregio Amsterdam) Kernteam Houtbouw, Belastingdienst, TU Delft, Erasmus

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,7 +27,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Wat is CircuLaw?</h2>
-              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-5 max-w-4xl'>
                 CircuLaw is een service waarmee we in de eerste plaats beleidsmakers en
                 transitiemanagers helpen meer en beter gebruik te maken van regelgeving om de
                 circulaire economie te bevorderen. Maar CircuLaw is ambitieus. Door stap voor stap
@@ -46,7 +46,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Waarom CircuLaw?</h2>
-              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-5 max-w-4xl'>
                 Voor het tegengaan van klimaatverandering, het verminderen van vervuiling, het
                 behoud van biodiversiteit en de beschikbaarheid van grondstoffen is een circulaire
                 economie essentieel. In Nederland hebben we hierin nog een lange weg te gaan. De
@@ -68,7 +68,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Hoever zijn we?</h2>
-              <ul className='p-mobile-bg sm:body-text py-5 max-w-4xl list-disc pl-6'>
+              <ul className='p-mobile-bg sm:p-desktop-bg py-5 max-w-4xl list-disc pl-6'>
                 <li>
                   Een overzicht van wet- en regelgeving voor beleidsmakers die aan de slag willen
                   met maatregelen voor de thema’s houtbouw en circulaire windmolens
@@ -91,7 +91,7 @@ export default function Index() {
             </div>
             <div>
               <h2 className='mobile sm:main'>Wie maken CircuLaw?</h2>
-              <p className='p-mobile-bg sm:body-text py-5 max-w-4xl'>
+              <p className='p-mobile-bg sm:p-desktop-bg py-5 max-w-4xl'>
                 Gemeente Amsterdam, Dark Matter Laboratories, EIT Climate KIC, de Provincies
                 Noord-Holland en Flevoland, Rijksdienst voor Ondernemend Nederland (RVO), het MRA
                 (Metropoolregio Amsterdam) Kernteam Houtbouw, Belastingdienst, TU Delft, Erasmus

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -42,7 +42,7 @@ const components = {
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
           <h3 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h3>
-          <div className='p-mobile-bg sm:body-text'>{value?.greenBoxText}</div> {/* need to change */}
+          <div className='p-mobile-bg sm:p-desktop-bg'>{value?.greenBoxText}</div> {/* need to change */}
         </div>
       </div>
     ),
@@ -84,7 +84,7 @@ const components = {
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
               <h3 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h3> {/* need to change text white */}
-              <p className='p-mobile-bg sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p> {/* need to change body text */}
+              <p className='p-mobile-bg sm:p-desktop-bg text-black-white-200 pb-4'>{value.pdfText}</p> {/* need to change body text */}
               <a
                 href={`https://cdn.sanity.io/files/${
                   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -41,7 +41,7 @@ const components = {
     greenBox: ({ value }) => (
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
-          <h2 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h2>
+          <h3 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h3>
           <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div>
         </div>
       </div>
@@ -83,7 +83,7 @@ const components = {
               <div className='absolute -bottom-44 -right-44 h-96 w-96 invisible md:visible'>
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
-              <h2 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h2>
+              <h3 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h3>
               <p className='body-text-mobile sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p>
               <a
                 href={`https://cdn.sanity.io/files/${
@@ -111,7 +111,7 @@ const components = {
     smallPara: ({ value }) => (
       <div className='flex justify-left pl-8 sm:pl-12'>
         <div className='mb-10 pt-10 w-5/6'>
-          <h4 className='mobile sm:desktop'>{value.smallParaTitle}</h4>
+          <h5 className='mobile sm:desktop'>{value.smallParaTitle}</h5>
           <p className='body-text-mobile sm:body-small'>{value.smallParaText}</p>
         </div>
       </div>
@@ -134,9 +134,9 @@ const components = {
     bullet: ({ children }) => <li className='py-0.5'>{children}</li>,
   },
   block: {
-    firstH2: ({ children }) => <h2 className='pb-8 mobile sm:desktop'>{children}</h2>,
-    h2: ({ children }) => <h2 className='py-8 mobile sm:desktop'>{children}</h2>,
-    h3: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>,
+    firstH2: ({ children }) => <h3 className='pb-8 mobile sm:desktop'>{children}</h3>,
+    h2: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>,
+    h3: ({ children }) => <h4 className='py-8 mobile sm:desktop'>{children}</h4>,
     // need to add other styles here
     normal: ({ children }) => (
       <p className='newlineDisplay body-text-mobile sm:body-text py-2'>{children}</p>
@@ -189,9 +189,9 @@ export default function TestMeasure({ data }) {
               )}
             </div>
             <div className='sm:col-span-12 row-span-1'>
-              <h1 className='lg:block sm:pt-4 pb-6 sm:pb-10 mobile sm:desktop'>
+              <h2 className='lg:block sm:pt-4 pb-6 sm:pb-10 mobile sm:desktop'>
                 {data?.measure?.titel}
-              </h1>
+              </h2>
             </div>
             {data?.measure?.subtitel && (
               <div className='sm:col-span-7 row-span-1'>

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -42,7 +42,7 @@ const components = {
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
           <h3 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h3>
-          <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div> {/* need to change */}
+          <div className='p-mobile-bg sm:body-text'>{value?.greenBoxText}</div> {/* need to change */}
         </div>
       </div>
     ),
@@ -84,7 +84,7 @@ const components = {
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
               <h3 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h3> {/* need to change text white */}
-              <p className='body-text-mobile sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p> {/* need to change body text */}
+              <p className='p-mobile-bg sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p> {/* need to change body text */}
               <a
                 href={`https://cdn.sanity.io/files/${
                   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
@@ -112,7 +112,7 @@ const components = {
       <div className='flex justify-left pl-8 sm:pl-12'>
         <div className='mb-10 pt-10 w-5/6'>
           <h5 className='mobile sm:desktop'>{value.smallParaTitle}</h5>
-          <p className='body-text-mobile sm:body-small'>{value.smallParaText}</p> {/* need to change */}
+          <p className='p-mobile-bg sm:body-small'>{value.smallParaText}</p> {/* need to change */}
         </div>
       </div>
     ),

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -42,7 +42,7 @@ const components = {
       <div className='-mx-8 sm:mx-0 my-10'>
         <div className='bg-green-300 w-full px-8 py-8'>
           <h3 className='pb-6 mobile sm:desktop'>{value?.greenBoxTitle}</h3>
-          <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div>
+          <div className='body-text-mobile sm:body-text'>{value?.greenBoxText}</div> {/* need to change */}
         </div>
       </div>
     ),
@@ -83,8 +83,8 @@ const components = {
               <div className='absolute -bottom-44 -right-44 h-96 w-96 invisible md:visible'>
                 <Image src='/pdf-deco.png' alt='decorative image' width={584} height={562} />
               </div>
-              <h3 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h3>
-              <p className='body-text-mobile sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p>
+              <h3 className='pb-2 mobile sm:desktop text-white'>{value.pdfTitle}</h3> {/* need to change text white */}
+              <p className='body-text-mobile sm:body-text text-black-white-200 pb-4'>{value.pdfText}</p> {/* need to change body text */}
               <a
                 href={`https://cdn.sanity.io/files/${
                   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '2vfoxb3h'
@@ -112,20 +112,20 @@ const components = {
       <div className='flex justify-left pl-8 sm:pl-12'>
         <div className='mb-10 pt-10 w-5/6'>
           <h5 className='mobile sm:desktop'>{value.smallParaTitle}</h5>
-          <p className='body-text-mobile sm:body-small'>{value.smallParaText}</p>
+          <p className='body-text-mobile sm:body-small'>{value.smallParaText}</p> {/* need to change */}
         </div>
       </div>
     ),
   },
   list: {
     bullet: ({ children }) => (
-      <div className='newlineDisplay body-text-mobile sm:body-text truncate'>
-        <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul>
+      <div className='newlineDisplay bullet-mobile sm:bullet-desktop truncate'> {/* need to change font */}
+        <ul className='list-disc pl-6 pb-4 mobile sm:main'>{children}</ul> {/* need to change font */}
       </div>
     ),
     number: ({ children }) => (
-      <div className='newlineDisplay body-text-mobile sm:body-text truncate'>
-        <ol className='list-decimal pl-6 pb-4 mobile sm:main'>{children}</ol>
+      <div className='newlineDisplay bullet-mobile sm:bullet-desktop truncate'> {/* need to change font */}
+        <ol className='list-decimal pl-6 pb-4 mobile sm:main'>{children}</ol> {/* need to change font */}
       </div>
     ),
   },
@@ -135,11 +135,11 @@ const components = {
   },
   block: {
     firstH2: ({ children }) => <h3 className='pb-8 mobile sm:desktop'>{children}</h3>,
-    h2: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>,
+    h2: ({ children }) => <h3 className='py-8 mobile sm:desktop'>{children}</h3>, 
     h3: ({ children }) => <h4 className='py-8 mobile sm:desktop'>{children}</h4>,
     // need to add other styles here
     normal: ({ children }) => (
-      <p className='newlineDisplay body-text-mobile sm:body-text py-2'>{children}</p>
+      <p className='newlineDisplay p-mobile-bg sm:p-desktop-bg py-2'>{children}</p>  // check if this is correct
     ),
   },
   marks: {
@@ -147,7 +147,7 @@ const components = {
       value.blank == true ? (
         <>
           <a
-            className='text-greenLink link-mobile sm:link inline-flex'
+            className='text-greenLink link-mobile sm:link inline-flex' 
             href={value.href}
             target='_blank'
             rel='noreferrer'
@@ -174,17 +174,17 @@ export default function TestMeasure({ data }) {
               {/* BREADCRUMB */}
               {data?.measure?.thema === 'houtbouw' && (
                 <Link href='/measures/houtbouw' className=''>
-                  <span className='breadcrumb'>{'<'} Terug</span>
+                  <span className='breadcrumb'>{'<'} Terug</span> {/* should all breadcrumbs be green this is black in figma */}
                 </Link>
               )}
               {data?.measure?.thema === 'circulaire-windturbines' && (
                 <Link href='/measures/windturbines' className=''>
-                  <span className='text-greenLink breadcrumb flex col-span-12'>← Terug</span>
+                  <span className='text-greenLink breadcrumb flex col-span-12'>← Terug</span> {/* should all breadcrumbs be green this is black in figma */}
                 </Link>
               )}
               {data?.measure?.thema === 'matrassen' && (
                 <Link href='/measures/matrassen' className=''>
-                  <span className='text-greenLink breadcrumb flex col-span-12'>← Terug</span>
+                  <span className='text-greenLink breadcrumb flex col-span-12'>← Terug</span> {/* should all breadcrumbs be green this is black in figma */}
                 </Link>
               )}
             </div>
@@ -195,7 +195,7 @@ export default function TestMeasure({ data }) {
             </div>
             {data?.measure?.subtitel && (
               <div className='sm:col-span-7 row-span-1'>
-                <p className='lg:block p-mobile-header sm:p-desktop-header pb-10'>
+                <p className='lg:block p-mobile-header sm:p-desktop-header pb-10'> {/* check font */}
                   {data?.measure?.subtitel}
                 </p>
               </div>

--- a/pages/measures/[slug].js
+++ b/pages/measures/[slug].js
@@ -67,7 +67,7 @@ const components = {
               fill='#F8FAF8'
             />
           </svg>
-          <div className='inline-block max-w-xs absolute invisible group-hover:visible z-10 py-3 px-6 bg-black-white-300 text-black-white-800tooltip-hover-text-mob sm:tooltip-hover-text opacity-0 group-hover:opacity-100 transition tooltip'>
+          <div className='inline-block max-w-xs absolute invisible group-hover:visible z-10 py-3 px-6 bg-black-white-300 text-black-white-800 popup-mobile sm:popup-desktop opacity-0 group-hover:opacity-100 transition tooltip'>
             {value.hoverText}
           </div>
         </button>
@@ -168,7 +168,7 @@ export default function TestMeasure({ data }) {
   return (
     <Layout>
       <div className='measure-bg'>
-        <div className='global-margin pt-4 sm:pt-10 '>
+        <div className='global-margin sm:pt-10 '>
           <div className='grid grid-cols-1 sm:grid-cols-12 content-center'>
             <div className='sm:col-span-12 row-span-1 h-12 mt-4'>
               {/* BREADCRUMB */}

--- a/pages/privacy-policy/index.js
+++ b/pages/privacy-policy/index.js
@@ -5,19 +5,19 @@ export default function Privacy() {
     <Layout>
       <div className='global-margin my-20 max-w-2xl text-black-white-800'>
         <h1 className='mobile sm:main pb-6'>Privacyverklaring</h1>
-        <p className='p-mobile-bg sm:body-text pt-2 pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pt-2 pb-6 max-w-4xl'>
           Het projectteam CircuLaw is verantwoordelijk voor de verwerking van persoonsgegevens zoals
           weergegeven in dit statement. CircuLaw Alfa is een alfaversie van het product CircuLaw.
           CircuLaw valt onder het beheer van de gemeente Amsterdam.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           Contactgegevens projectteam CircuLaw:{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>
           </span>
         </p>
         <h2 className='mobile sm:main py-2'>Wanneer verwerken wij persoonsgegevens</h2>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           Wanneer je je registreert of aanmeldt voor een van onze producten, diensten of
           activiteiten, je aanmeldt voor een nieuwsbrief, deelneemt aan een bijeenkomst, gebruik
           maakt van onze digitale diensten, contact opneemt met het projectteam van CircuLaw of op
@@ -27,14 +27,14 @@ export default function Privacy() {
           belang, artikel 6, eerste lid, sub f, van de AVG.
         </p>
         <h2 className='mobile sm:main py-2'>Welke gegevens verwerken wij</h2>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           We verwerken jouw registratiegegevens. Dit zijn de gegevens die wij je verzoeken in te
           vullen bij registratie zoals naam, e-mailadres, telefoonnummer, functie, naam
           werkgever/bedrijf en de vestigingsplaats van het bedrijf. Voor de verwerking van jouw
           gegevens maken wij geen gebruik van AI-technieken.
         </p>
         <h2 className='mobile sm:main py-2'>Met welk doel verwerken wij je persoonsgegevens</h2>
-        <div className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <div className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           We verwerken je persoonsgegevens
           <ul className='list-disc pl-6'>
             <li>om je te informeren over ons product;</li>
@@ -53,11 +53,11 @@ export default function Privacy() {
         <h2 className='mobile sm:main py-2'>
           Wanneer verstrekken wij je persoonsgegevens aan derden
         </h2>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>Dit doen wij nooit.</p>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>Dit doen wij nooit.</p>
         <h2 className='mobile sm:main py-2'>
           Hoe zit het met links naar websites van derde partijen
         </h2>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           Als je via de website of andere diensten of producten van CircuLaw terecht komt op de
           website van een derde, zijn de voorwaarden en privacyregels van de betreffende derde van
           toepassing. CircuLaw controleert de activiteiten van dergelijke websites of derde partijen
@@ -67,12 +67,12 @@ export default function Privacy() {
           (persoonlijke) informatie verschaft.
         </p>
         <h2 className='mobile sm:main py-2'>Wat zijn jouw rechten?</h2>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Je hebt het recht op inzage in je persoonsgegevens en het recht om correctie, verwijdering
           of overdracht van je persoonsgegevens te vragen. Daarnaast heb je het recht bezwaar te
           maken tegen het verwerken van je gegevens.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           CircuLaw biedt je de mogelijkheid om jouw gegevens in te zien, te laten wijzigen of te
           laten verwijderen. Je kunt dit doen door een email te sturen naar het projectteam. Als je
           geen marketing en promotieberichten over onze producten en diensten of algemene
@@ -80,27 +80,27 @@ export default function Privacy() {
           de instructies te volgen die in elke e-mail hiervoor zijn opgenomen, dan wel door een
           bericht te sturen naar het projectteam van CircuLaw.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           Als je het niet eens zijn met de manier waarop CircuLaw omgaat met je persoonsgegevens dan
           kun je een klacht indienen bij de Autoriteit Persoonsgegevens.
         </p>
         <h2 className='mobile sm:main py-2'>Hoe lang bewaren we je gegevens?</h2>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           CircuLaw bewaart je persoonsgegevens zolang als dat nodig is voor de doelen die hierboven
           zijn genoemd of om te voldoen aan wettelijke (bewaar)verplichtingen.
         </p>
         <h2 className='mobile sm:main py-2'>Hoe gaan we om met cookies?</h2>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Een cookie is een klein tekstbestand dat onzichtbaar is voor de gebruiker en dat de
           browser opslaat op de computer of het mobiele apparaat van de gebruiker wanneer de
           gebruiker een website bezoekt.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Op grond van artikel 11.7a van de Telecommunicatiewet (Tw) moeten de bezoekers van de
           website geïnformeerd worden over en toestemming geven voor het plaatsen en/of uitlezen van
           cookies op hun apparaat (zoals hun computer, laptop of smartphone).
         </p>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           Er zijn uitzonderingen op het toestemmingsvereiste. Bijvoorbeeld als de cookies technisch
           noodzakelijk zijn om de website goed te laten werken. Dit noemen we functionele cookies.
           Ook is er een uitzondering voor bepaalde analytische cookies. Er is bijvoorbeeld geen
@@ -108,13 +108,13 @@ export default function Privacy() {
           gebruikt worden om bezoekers te tellen. Met analytische cookies krijgen wij beter inzicht
           in het functioneren van onze website.
         </p>
-        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-10 max-w-4xl'>
           CircuLaw maakt alleen gebruik van functionele en analytische cookies waar geen toestemming
           voor gevraagd hoeft te worden.
         </p>
 
         <h2 className='mobile sm:main py-2'>Wijziging van deze Privacyverklaring</h2>
-        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:p-desktop-bg pb-6 max-w-4xl'>
           De gemeente Amsterdam heeft het recht om haar Privacyverklaring te wijzigen. Als er
           inhoudelijke wijzigingen worden doorgevoerd, maken we dit bekend via de website{' '}
           <span className='text-greenLink link-mobile sm:link'>
@@ -124,7 +124,7 @@ export default function Privacy() {
           </span>
           .{' '}
         </p>
-        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:p-desktop-bg max-w-4xl pb-6'>
           Heb je vragen naar aanleiding van deze Privacyverklaring? Mail ons dan op{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>

--- a/pages/privacy-policy/index.js
+++ b/pages/privacy-policy/index.js
@@ -5,19 +5,19 @@ export default function Privacy() {
     <Layout>
       <div className='global-margin my-20 max-w-2xl text-black-white-800'>
         <h1 className='mobile sm:main pb-6'>Privacyverklaring</h1>
-        <p className='body-text-mobile sm:body-text pt-2 pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pt-2 pb-6 max-w-4xl'>
           Het projectteam CircuLaw is verantwoordelijk voor de verwerking van persoonsgegevens zoals
           weergegeven in dit statement. CircuLaw Alfa is een alfaversie van het product CircuLaw.
           CircuLaw valt onder het beheer van de gemeente Amsterdam.
         </p>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           Contactgegevens projectteam CircuLaw:{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>
           </span>
         </p>
         <h2 className='mobile sm:main py-2'>Wanneer verwerken wij persoonsgegevens</h2>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           Wanneer je je registreert of aanmeldt voor een van onze producten, diensten of
           activiteiten, je aanmeldt voor een nieuwsbrief, deelneemt aan een bijeenkomst, gebruik
           maakt van onze digitale diensten, contact opneemt met het projectteam van CircuLaw of op
@@ -27,14 +27,14 @@ export default function Privacy() {
           belang, artikel 6, eerste lid, sub f, van de AVG.
         </p>
         <h2 className='mobile sm:main py-2'>Welke gegevens verwerken wij</h2>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           We verwerken jouw registratiegegevens. Dit zijn de gegevens die wij je verzoeken in te
           vullen bij registratie zoals naam, e-mailadres, telefoonnummer, functie, naam
           werkgever/bedrijf en de vestigingsplaats van het bedrijf. Voor de verwerking van jouw
           gegevens maken wij geen gebruik van AI-technieken.
         </p>
         <h2 className='mobile sm:main py-2'>Met welk doel verwerken wij je persoonsgegevens</h2>
-        <div className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <div className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           We verwerken je persoonsgegevens
           <ul className='list-disc pl-6'>
             <li>om je te informeren over ons product;</li>
@@ -53,11 +53,11 @@ export default function Privacy() {
         <h2 className='mobile sm:main py-2'>
           Wanneer verstrekken wij je persoonsgegevens aan derden
         </h2>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>Dit doen wij nooit.</p>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>Dit doen wij nooit.</p>
         <h2 className='mobile sm:main py-2'>
           Hoe zit het met links naar websites van derde partijen
         </h2>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           Als je via de website of andere diensten of producten van CircuLaw terecht komt op de
           website van een derde, zijn de voorwaarden en privacyregels van de betreffende derde van
           toepassing. CircuLaw controleert de activiteiten van dergelijke websites of derde partijen
@@ -67,12 +67,12 @@ export default function Privacy() {
           (persoonlijke) informatie verschaft.
         </p>
         <h2 className='mobile sm:main py-2'>Wat zijn jouw rechten?</h2>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Je hebt het recht op inzage in je persoonsgegevens en het recht om correctie, verwijdering
           of overdracht van je persoonsgegevens te vragen. Daarnaast heb je het recht bezwaar te
           maken tegen het verwerken van je gegevens.
         </p>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           CircuLaw biedt je de mogelijkheid om jouw gegevens in te zien, te laten wijzigen of te
           laten verwijderen. Je kunt dit doen door een email te sturen naar het projectteam. Als je
           geen marketing en promotieberichten over onze producten en diensten of algemene
@@ -80,27 +80,27 @@ export default function Privacy() {
           de instructies te volgen die in elke e-mail hiervoor zijn opgenomen, dan wel door een
           bericht te sturen naar het projectteam van CircuLaw.
         </p>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           Als je het niet eens zijn met de manier waarop CircuLaw omgaat met je persoonsgegevens dan
           kun je een klacht indienen bij de Autoriteit Persoonsgegevens.
         </p>
         <h2 className='mobile sm:main py-2'>Hoe lang bewaren we je gegevens?</h2>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           CircuLaw bewaart je persoonsgegevens zolang als dat nodig is voor de doelen die hierboven
           zijn genoemd of om te voldoen aan wettelijke (bewaar)verplichtingen.
         </p>
         <h2 className='mobile sm:main py-2'>Hoe gaan we om met cookies?</h2>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Een cookie is een klein tekstbestand dat onzichtbaar is voor de gebruiker en dat de
           browser opslaat op de computer of het mobiele apparaat van de gebruiker wanneer de
           gebruiker een website bezoekt.
         </p>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Op grond van artikel 11.7a van de Telecommunicatiewet (Tw) moeten de bezoekers van de
           website geïnformeerd worden over en toestemming geven voor het plaatsen en/of uitlezen van
           cookies op hun apparaat (zoals hun computer, laptop of smartphone).
         </p>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           Er zijn uitzonderingen op het toestemmingsvereiste. Bijvoorbeeld als de cookies technisch
           noodzakelijk zijn om de website goed te laten werken. Dit noemen we functionele cookies.
           Ook is er een uitzondering voor bepaalde analytische cookies. Er is bijvoorbeeld geen
@@ -108,13 +108,13 @@ export default function Privacy() {
           gebruikt worden om bezoekers te tellen. Met analytische cookies krijgen wij beter inzicht
           in het functioneren van onze website.
         </p>
-        <p className='body-text-mobile sm:body-text pb-10 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-10 max-w-4xl'>
           CircuLaw maakt alleen gebruik van functionele en analytische cookies waar geen toestemming
           voor gevraagd hoeft te worden.
         </p>
 
         <h2 className='mobile sm:main py-2'>Wijziging van deze Privacyverklaring</h2>
-        <p className='body-text-mobile sm:body-text pb-6 max-w-4xl'>
+        <p className='p-mobile-bg sm:body-text pb-6 max-w-4xl'>
           De gemeente Amsterdam heeft het recht om haar Privacyverklaring te wijzigen. Als er
           inhoudelijke wijzigingen worden doorgevoerd, maken we dit bekend via de website{' '}
           <span className='text-greenLink link-mobile sm:link'>
@@ -124,7 +124,7 @@ export default function Privacy() {
           </span>
           .{' '}
         </p>
-        <p className='body-text-mobile sm:body-text max-w-4xl pb-6'>
+        <p className='p-mobile-bg sm:body-text max-w-4xl pb-6'>
           Heb je vragen naar aanleiding van deze Privacyverklaring? Mail ons dan op{' '}
           <span className='text-greenLink link-mobile sm:link'>
             <a href='mailto:info@circulaw.nl'>info@circulaw.nl</a>


### PR DESCRIPTION
I started fixing up some of the styles in the measure page (the components for portable text). The measure page is still not in the final figma and the thema page has not been updated with the new font names in figma either so I did not do all of it. 
For the about pages i just copied and pasted the portable text components so once it is all looking good for the measures we can copy and past it over to the about/slug page. 

I also changed all of the body text and body text mobile to p-desktop-bg and p-mobile-bg.