### PR TITLE
Fix cron comment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,14 @@ name: Backup Routine
 on:
   schedule:
     # Runs at 10:00 UTC on every day-of-month divisible by 30
+    #        .-------------- minute (0 - 59)
+    #        |  .----------- hour (0 - 23)
+    #        |  |  .-------- day of month (1 - 31)
+    #        |  |  |   .---- month (1 - 12) OR jan,feb,mar,apr ...
+    #        |  |  |   | .-- day of week (0 - 6) (Sunday=0 or 7)
+    #        |  |  |   | |            OR sun,mon,tue,wed,thu,fri,sat
+    #        |  |  |   | |
+    #        *  *  *   * * user-name  command to be executed
     - cron: "0 10 */30 * *"
 jobs:
   backup-dataset:


### PR DESCRIPTION
This does not alter the GitHub workflow, only adds comments.

However, it should be noted that the current schedule seems to not run in February, thus I expect the "*/30" should be changed to be a "1" to run on the first of every month.

Also, I note that the retention of backups is set to be shorter than the run interval, I expect this should be changed to match.