### PR TITLE
Standard for public code assessment 2023-07-03

### DIFF
--- a/docs/circulaw-standard-for-public-code.html
+++ b/docs/circulaw-standard-for-public-code.html
@@ -4,7 +4,7 @@
 <!-- SPDX-FileCopyrightText: 2022-2023 by The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
 <head>
 <meta charset="UTF-8">
-<title>________ and the Standard for Public Code</title>
+<title>CircuLaw and the Standard for Public Code</title>
 <style>
 html, body {
 font-family: Mulish;
@@ -45,7 +45,7 @@ background-color: #f6f8fa;
 </style>
 </head>
 <body>
-<h1>CircuLaw and the Standard for Public Code version 0.7.0</h1>
+<h1>CircuLaw and the Standard for Public Code version <span class="standard-version">0.7.1</span></h1>
 
 Link to commitment to meet the Standard for Public Code:
 
@@ -173,11 +173,11 @@ Continuous integration tests SHOULD validate that the source code and the policy
 
 </table>
 
-<h2><a href="https://standard.publiccode.net/criteria/create-reusable-and-portable-code.html">Create reusable and portable code</a></h2>
+<h2><a href="https://standard.publiccode.net/criteria/make-the-codebase-reusable-and-portable.html">Make the codebase reusable and portable</a></h2>
 
 &#9744;<!-- &#9745; --> criterion met.
 
-<table id="create-reusable-and-portable-code" style="width:100%">
+<table id="make-the-codebase-reusable-and-portable" style="width:100%">
 <tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
 <tr>
 <td>
@@ -196,7 +196,7 @@ Currently tied to the Dutch context (and modular within it), but there is ambiti
 
 </td>
 <td>
-The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding.
+The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed software or services for execution and understanding.
 </td>
 <td>
 We are using some known blockers: Hotjar, GetForm as they are paid and non-open licensed services which we will remove and replace.
@@ -244,7 +244,7 @@ Multiple <a href="https://www.circulaw.nl/about/Wie-maken-CircuLaw">partners</a>
 
 </td>
 <td>
-Configuration SHOULD be used to make code adapt to context specific needs.
+Configuration SHOULD be used to make source code adapt to context specific needs.
 </td>
 <td>
 Currently created for one context but aspiration to make it configurable.
@@ -268,7 +268,7 @@ The codebase SHOULD be localizable.
 
 </td>
 <td>
-Code and its documentation SHOULD NOT contain situation-specific information.
+Source code and its documentation SHOULD NOT contain situation-specific information.
 </td>
 <td>
 
@@ -292,7 +292,7 @@ Codebase modules SHOULD be documented in such a way as to enable reuse in codeba
 
 </td>
 <td>
-The code SHOULD NOT require services or platforms available from only a single vendor.
+The software SHOULD NOT require services or platforms available from only a single vendor.
 </td>
 <td>
 Once the proprietary pieces are removed this will be met.
@@ -636,7 +636,7 @@ Documenting the process can be clearer.
 Ok
 </td>
 <td>
-Reviews SHOULD include running both the code and the tests of the codebase.
+Reviews SHOULD include running both the software and the tests of the codebase.
 </td>
 <td>
 The process to review and test the code exists however the scope of the testing can be broadened. 
@@ -748,7 +748,7 @@ Documenting the objectives of the codebase for the general public is OPTIONAL.
 
 </td>
 <td>
-All of the functionality of the codebase, policy as well as source, MUST be described in language clearly understandable for those that understand the purpose of the code.
+All of the functionality of the codebase, policy as well as source code, MUST be described in language clearly understandable for those that understand the purpose of the codebase.
 </td>
 <td>
 
@@ -760,7 +760,7 @@ All of the functionality of the codebase, policy as well as source, MUST be desc
 
 </td>
 <td>
-The documentation of the codebase MUST contain a description of how to install and run the source code.
+The documentation of the codebase MUST contain a description of how to install and run the software.
 </td>
 <td>
 The Getting Started section needs to have dependencies, otherwise good.
@@ -877,7 +877,7 @@ All codebase documentation MUST be in English.
 
 </td>
 <td>
-All code MUST be in English, except where policy is machine interpreted as code.
+All source code MUST be in English, except where policy is machine interpreted as code.
 </td>
 <td>
 We will create a glossary for Dutch and legal instrument specific terms in the codebase.
@@ -1157,7 +1157,7 @@ Testing policy and documentation for style and broken links is OPTIONAL.
 
 </td>
 <td>
-Testing the code by using examples in the documentation is OPTIONAL.
+Testing the software by using examples in the documentation is OPTIONAL.
 </td>
 <td>
 Once we add the examples, we will link them into test script.
@@ -1177,7 +1177,7 @@ Once we add the examples, we will link them into test script.
 Ok
 </td>
 <td>
-All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable.
+All source code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable.
 </td>
 <td>
 
@@ -1201,7 +1201,7 @@ Software source code MUST be licensed under an <a href="https://spdx.org/license
 Ok
 </td>
 <td>
-All code MUST be published with a license file.
+All source code MUST be published with a license file.
 </td>
 <td>
 <a href="https://github.com/Dark-Matter-Labs/circulaw/blob/main/LICENSE.md">LICENSE-md</a>
@@ -1237,7 +1237,7 @@ We do not hold any copyright yet but are in the process to get one and we will d
 
 </td>
 <td>
-Having multiple licenses for different types of code and documentation is OPTIONAL.
+Having multiple licenses for different types of source code and documentation is OPTIONAL.
 </td>
 <td>
 

--- a/docs/circulaw-standard-for-public-code.html
+++ b/docs/circulaw-standard-for-public-code.html
@@ -1,0 +1,1513 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+<!-- SPDX-FileCopyrightText: 2022-2023 by The Foundation for Public Code <info@publiccode.net>, https://standard.publiccode.net/AUTHORS -->
+<head>
+<meta charset="UTF-8">
+<title>________ and the Standard for Public Code</title>
+<style>
+html, body {
+font-family: Mulish;
+font-size: 11pt;
+}
+h1, h2 {
+font-weight: normal;
+position: relative;
+}
+h1 {
+margin-top: 0;
+font-size: 1.5cm;
+border-bottom: none;
+}
+h2 {
+font-size: 1.5em;
+}
+@media print {
+a {
+color: #111;
+text-decoration: none;
+}
+th {
+font-weight: 600;
+}
+td {
+padding: 6px 13px;
+border: 1px solid #dfe2e5;
+}
+tr {
+background-color: #fff;
+border-top: 1px solid #c6cbd1;
+}
+tr:nth-child(2n) {
+background-color: #f6f8fa;
+}
+}
+</style>
+</head>
+<body>
+<h1>CircuLaw and the Standard for Public Code version 0.7.0</h1>
+
+Link to commitment to meet the Standard for Public Code:
+
+<h2><a href="https://standard.publiccode.net/criteria/code-in-the-open.html">Code in the open</a></h2>
+
+&#9745;<!-- &#9745; --> criterion met.
+
+<table id="code-in-the-open" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+N/A
+</td>
+<td>
+All source code for any policy in use (unless used for fraud detection) MUST be published and publicly accessible.
+</td>
+<td>
+The codebase doesn't directly implement a policy but is a toolbox to create policy.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+All source code for any software in use (unless used for fraud detection) MUST be published and publicly accessible.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase MUST NOT contain sensitive information regarding users, their organization or third parties.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Any source code not currently in use (such as new versions, proposals or older versions) SHOULD be published.
+</td>
+<td>
+<a href="https://github.com/Dark-Matter-Labs/circulaw/releases">GitHub releases</a>
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Documenting which source code or policy underpins any specific interaction the general public may have with an organization is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/bundle-policy-and-source-code.html">Bundle policy and source code</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="bundle-policy-and-source-code" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST include the policy that the source code is based on.
+</td>
+<td>
+Add links to Amsterdam documents in README
+</td>
+</tr>
+
+<tr>
+<td>
+N/A
+</td>
+<td>
+If a policy is based on source code, that source code MUST be included in the codebase, unless used for fraud detection.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Policy SHOULD be provided in machine readable and unambiguous formats.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+N/A
+</td>
+<td>
+Continuous integration tests SHOULD validate that the source code and the policy are executed coherently.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/create-reusable-and-portable-code.html">Create reusable and portable code</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="create-reusable-and-portable-code" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST be developed to be reusable in different contexts.
+</td>
+<td>
+Currently tied to the Dutch context (and modular within it), but there is ambition to internationlize it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding.
+</td>
+<td>
+We are using some known blockers: Hotjar, GetForm as they are paid and non-open licensed services which we will remove and replace.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD be in use by multiple parties.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The roadmap SHOULD be influenced by the needs of multiple parties.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The development of the codebase SHOULD be a collaboration between multiple parties.
+</td>
+<td>
+Multiple <a href="https://www.circulaw.nl/about/Wie-maken-CircuLaw">partners</a> have provided input to guide development
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Configuration SHOULD be used to make code adapt to context specific needs.
+</td>
+<td>
+Currently created for one context but aspiration to make it configurable.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD be localizable.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Code and its documentation SHOULD NOT contain situation-specific information.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Codebase modules SHOULD be documented in such a way as to enable reuse in codebases in other contexts.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The code SHOULD NOT require services or platforms available from only a single vendor.
+</td>
+<td>
+Once the proprietary pieces are removed this will be met.
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/welcome-contributors.html">Welcome contributors</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="welcome-contributors" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST allow anyone to submit suggestions for changes to the codebase.
+</td>
+<td>
+Currently we use Notion to track our tasks in a private space. We will document better in our README to create Issues in Github and we will connect the two systems together.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST include contribution guidelines explaining what kinds of contributions are welcome and how contributors can get involved, for example in a `CONTRIBUTING` file.
+</td>
+<td>
+Currently there is a private notion page which describes how to contribute, we will make it public in our repo and also stare clearly what ways we expect them to suggest changes.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST document the governance of the codebase, contributions and its community, for example in a `GOVERNANCE` file.
+</td>
+<td>
+We do not have a clear governance description written down at the moment!
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The contribution guidelines SHOULD document who is expected to cover the costs of reviewing contributions.
+</td>
+<td>
+Dark Matter Labs will supply developers to review needed contributions as part of their production role on the project.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD advertise the committed engagement of involved organizations in the development and maintenance.
+</td>
+<td>
+We have this written in our web app but we will add a link of this to our README and also create an english version/summary available. 
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD have a publicly available roadmap.
+</td>
+<td>
+We do not have a public roadmap yet!
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase SHOULD publish codebase activity statistics.
+</td>
+<td>
+<a href="https://github.com/Dark-Matter-Labs/circulaw/pulse">GitHub Pulse</a>
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Including a code of conduct for contributors in the codebase is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/make-contributing-easy.html">Make contributing easy</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="make-contributing-easy" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST have a public issue tracker that accepts suggestions from anyone.
+</td>
+<td>
+See first requirement on Welcome contributors.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a `README` file.
+</td>
+<td>
+We will link to the private issue tracker and apologise that in current beta stage it is behind password for now and we aspire to open this up. For now, we will monitor Issues in Github and cross link to the private space.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST have communication channels for users and developers, for example email lists.
+</td>
+<td>
+Currently we use a paid instance of Slack where we communicate, when we go beyond beta we will create a way to others to enter.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+There MUST be a way to report security issues for responsible disclosure over a closed channel.
+</td>
+<td>
+We do not have such channels at the moment but will set it up.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation MUST include instructions for how to report potentially security sensitive issues.
+</td>
+<td>
+We do not have such documentation at the moment but will set it up.
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/maintain-version-control.html">Maintain version control</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="maintain-version-control" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+Ok
+</td>
+<td>
+All files in the codebase MUST be version controlled.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+All decisions MUST be documented in commit messages.
+</td>
+<td>
+Decisions are not fully visible in the pull requests yet. We will create a better system to make sure the important bits are either mentioned or linked with open ticket.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Every commit message MUST link to discussions and issues wherever possible.
+</td>
+<td>
+(see previous)
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase SHOULD be maintained in a distributed version control system.
+</td>
+<td>
+Git
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Contribution guidelines SHOULD require contributors to group relevant changes in commits.
+</td>
+<td>
+Not there currently, we will add it to Contributing guide.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels.
+</td>
+<td>
+<a href="https://github.com/Dark-Matter-Labs/circulaw/releases">GitHub releases</a> is used, but can be improved. (Consider bumping +0.0.1 for each merge to production, and updating a ChangeLog)
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Contribution guidelines SHOULD encourage file formats where the changes within the files can be easily viewed and understood in the version control system.
+</td>
+<td>
+Not currently documented, but practiced.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+It is OPTIONAL for contributors to sign their commits and provide an email address, so that future contributors are able to contact past contributors with questions about their work.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/require-review-of-contributions.html">Require review of contributions</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="require-review-of-contributions" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+All contributions that are accepted or committed to release versions of the codebase MUST be reviewed by another contributor.
+</td>
+<td>
+Release to productions are done together. Require review could better documented and more systematic (reviewer to merge?).
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Reviews MUST include source, policy, tests and documentation.
+</td>
+<td>
+(Consider review and/or commit template)
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Reviewers MUST provide feedback on all decisions to not accept a contribution.
+</td>
+<td>
+Put feedback in GitHub rather than in Slack.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The review process SHOULD confirm that a contribution conforms to the standards, architecture and decisions set out in the codebase in order to pass review.
+</td>
+<td>
+Documenting the process can be clearer.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Reviews SHOULD include running both the code and the tests of the codebase.
+</td>
+<td>
+The process to review and test the code exists however the scope of the testing can be broadened. 
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Contributions SHOULD be reviewed by someone in a different context than the contributor.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Version control systems SHOULD NOT accept non-reviewed contributions in release versions.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Reviews SHOULD happen within two business days.
+</td>
+<td>
+Add statement of intent: we aim to review contributions within X days. 
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Performing reviews by multiple reviewers is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/document-codebase-objectives.html">Document codebase objectives</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="document-codebase-objectives" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST contain documentation of its objectives, like a mission and goal statement, that is understandable by developers and designers so that they can use or contribute to the codebase.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Codebase documentation SHOULD clearly describe the connections between policy objectives and codebase objectives.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Documenting the objectives of the codebase for the general public is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/document-the-code.html">Document the code</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="document-the-code" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+All of the functionality of the codebase, policy as well as source, MUST be described in language clearly understandable for those that understand the purpose of the code.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation of the codebase MUST contain a description of how to install and run the source code.
+</td>
+<td>
+The Getting Started section needs to have dependencies, otherwise good.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation of the codebase MUST contain examples demonstrating the key functionality.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation of the codebase SHOULD contain a high level description that is clearly understandable for a wide audience of stakeholders, like the general public and journalists.
+</td>
+<td>
+We have it as a blog but need to link to the codebase.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation of the codebase SHOULD contain a section describing how to install and run a standalone version of the source code, including, if necessary, a test dataset.
+</td>
+<td>
+We have a script to run Sanity CMS locally but we can highlight this better in our documentation.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation of the codebase SHOULD contain examples for all functionality.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The documentation SHOULD describe the key components or modules of the codebase and their relationships, for example as a high level architectural diagram.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+There SHOULD be continuous integration tests for the quality of the documentation.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Including examples that make users want to immediately start using the codebase in the documentation of the codebase is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/use-plain-english.html">Use plain English</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="use-plain-english" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+Ok
+</td>
+<td>
+All codebase documentation MUST be in English.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+
+</td>
+<td>
+All code MUST be in English, except where policy is machine interpreted as code.
+</td>
+<td>
+We will create a glossary for Dutch and legal instrument specific terms in the codebase.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+All bundled policy not available in English MUST have an accompanying summary in English.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Any translation MUST be up to date with the English version and vice versa.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+There SHOULD be no acronyms, abbreviations, puns or legal/non-English/domain specific terms in the codebase without an explanation preceding it or a link to an explanation.
+</td>
+<td>
+We will do a check on this!
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Documentation SHOULD aim for a lower secondary education reading level, as recommended by the <a href="https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=315#readable">Web Content Accessibility Guidelines 2</a>.
+</td>
+<td>
+Once our documentation is in a better place, we will get it reviewed by domain specific expert.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Providing a translation of any code, documentation or tests is OPTIONAL.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/use-open-standards.html">Use open standards</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="use-open-standards" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+N/A
+</td>
+<td>
+For features of the codebase that facilitate the exchange of data the codebase MUST use an open standard that meets the <a href="https://opensource.org/osr">Open Source Initiative Open Standard Requirements</a>.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Any non-open standards used MUST be recorded clearly as such in the documentation.
+</td>
+<td>
+We should describe that content work needs to be in sync with Sanity's set standards. We need to link GROQ specification to our codebase. https://github.com/sanity-io/GROQ
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Any standard chosen for use within the codebase MUST be listed in the documentation with a link to where it is available.
+</td>
+<td>
+We should describe that content work needs to be in sync with Sanity's set standards. We need to link GROQ specification to our codebase. https://github.com/sanity-io/GROQ
+</td>
+</tr>
+
+<tr>
+<td>
+N/A
+</td>
+<td>
+Any non-open standards chosen for use within the codebase MUST NOT hinder collaboration and reuse.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+N/A
+</td>
+<td>
+If no existing open standard is available, effort SHOULD be put into developing one.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Open standards that are machine testable SHOULD be preferred over open standards that are not.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Non-open standards that are machine testable SHOULD be preferred over non-open standards that are not.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/use-continuous-integration.html">Use continuous integration</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="use-continuous-integration" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+All functionality in the source code MUST have automated tests.
+</td>
+<td>
+We do not have this yet and will work on it.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Contributions MUST pass all automated tests before they are admitted into the codebase.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST have guidelines explaining how to structure contributions.
+</td>
+<td>
+We have it but it is in a private space. We will bring this into our open repo as CONTRIBUTING.md file
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase MUST have active contributors who can review contributions.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Automated test results for contributions SHOULD be public.
+</td>
+<td>
+Some tests might be locked behind Vercel login, we will test this functionality out.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase guidelines SHOULD state that each contribution should focus on a single issue.
+</td>
+<td>
+We have it but it is in a private space. We will bring this into our open repo as CONTRIBUTING.md file
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Source code test and documentation coverage SHOULD be monitored.
+</td>
+<td>
+We monitor but we should document the process + where to find all the key info.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Testing policy and documentation for consistency with the source and vice versa is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Testing policy and documentation for style and broken links is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Testing the code by using examples in the documentation is OPTIONAL.
+</td>
+<td>
+Once we add the examples, we will link them into test script.
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/publish-with-an-open-license.html">Publish with an open license</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="publish-with-an-open-license" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+Ok
+</td>
+<td>
+All code and documentation MUST be licensed such that it may be freely reusable, changeable and redistributable.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Software source code MUST be licensed under an <a href="https://spdx.org/licenses/">OSI-approved or FSF Free/Libre license</a>.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+All code MUST be published with a license file.
+</td>
+<td>
+<a href="https://github.com/Dark-Matter-Labs/circulaw/blob/main/LICENSE.md">LICENSE-md</a>
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Contributors MUST NOT be required to transfer copyright of their contributions to the codebase.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+All source code files in the codebase SHOULD include a copyright notice and a license header that are machine-readable.
+</td>
+<td>
+We do not hold any copyright yet but are in the process to get one and we will document that in the codebase in a machine readable format. Type of license + who owns the copyright, who to contant and ask questions.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Having multiple licenses for different types of code and documentation is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/make-the-codebase-findable.html">Make the codebase findable</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="make-the-codebase-findable" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+Ok
+</td>
+<td>
+The name of the codebase SHOULD be descriptive and free from acronyms, abbreviations, puns or organizational branding.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD have a short description that helps someone understand what the codebase is for or what it does.
+</td>
+<td>
+We have a basic tagline but need make it more descriptive and understandable.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Maintainers SHOULD submit the codebase to relevant software catalogs.
+</td>
+<td>
+We do not have a publiccode.yml but we will add one. https://github.com/publiccodeyml/publiccode.yml
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).
+</td>
+<td>
+<a href="https://circulaw.org">Circulaw.org</a>
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+The codebase SHOULD be findable using a search engine by codebase name.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD be findable using a search engine by describing the problem it solves in natural language.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD have a unique and persistent identifier where the entry mentions the major contributors, repository location and website.
+</td>
+<td>
+We will link the identifer to our codebase.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD include a machine-readable metadata description, for example in a <a href="https://github.com/publiccodeyml/publiccode.yml">publiccode.yml</a> file.
+</td>
+<td>
+We do not have this yet but will add.
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+A dedicated domain name for the codebase is OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Regular presentations at conferences by the community are OPTIONAL.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/use-a-coherent-style.html">Use a coherent style</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="use-a-coherent-style" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase.
+</td>
+<td>
+We need to add engineering guidelines to document and explain how ESLint and Prettier work, along with husky(git pre-commit hook)
+</td>
+</tr>
+
+<tr>
+<td>
+Ok
+</td>
+<td>
+Contributions SHOULD pass automated tests on style.
+</td>
+<td>
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The style guide SHOULD include expectations for inline comments and documentation for non-trivial sections.
+</td>
+<td>
+We need to document all the expectations and rules in our codebase.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Including expectations for <a href="https://standard.publiccode.net/criteria/use-plain-english.html">understandable English</a> in the style guide is OPTIONAL.
+</td>
+<td>
+We will add this when we create the style guide.
+</td>
+</tr>
+
+</table>
+
+<h2><a href="https://standard.publiccode.net/criteria/document-codebase-maturity.html">Document codebase maturity</a></h2>
+
+&#9744;<!-- &#9745; --> criterion met.
+
+<table id="document-codebase-maturity" style="width:100%">
+<tr><th>Meets</th><th>Requirement</th><th style="width:25%">Notes and links</th></tr>
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST be versioned.
+</td>
+<td>
+We are improving our point based versionsioning. The alpha is 1.0.0 and beta is 2.0.0. We need to document top of the README about the current version and that it is not in production yet!
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase MUST prominently document whether or not there are versions of the codebase that are ready to use.
+</td>
+<td>
+ We need to document top of the README about the current version and that it is not in production yet!
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+Codebase versions that are ready to use MUST only depend on versions of other codebases that are also ready to use.
+</td>
+<td>
+Document which non production ready packages we use!
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The codebase SHOULD contain a log of changes from version to version, for example in the `CHANGELOG`.
+</td>
+<td>
+We will add better change notes and create a place in the website to view them.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+The method for assigning version identifiers SHOULD be documented.
+</td>
+<td>
+We need to explain better our versioning strategy.
+</td>
+</tr>
+
+<tr>
+<td>
+
+</td>
+<td>
+It is OPTIONAL to use semantic versioning.
+</td>
+<td>
+
+</td>
+</tr>
+
+</table>
+</body>
+</html>


### PR DESCRIPTION
This reflects the findings of the assessment session conducted with @gurdenbatra, @theocampbell, @Ainali, and @ericherman on 2023-07-03.

The requirement texts have been updated to reflect the minor wording updates from [0.7.0 to 0.7.1](https://github.com/publiccodenet/standard/compare/0.7.0%E2%80%A60.7.1#diff-e86a9c00b497646f894a2478ed7d9461361c29cb085f7c820be30920bb1e289e)